### PR TITLE
Stop exporting mean_and_cov_diag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.1.4"
+version = "0.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.2"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -7,7 +7,7 @@ module AbstractGPs
     using Random
     using Statistics
 
-    export GP, mean, cov, std, cov_diag, mean_and_cov, mean_and_cov_diag, marginals, rand,
+    export GP, mean, cov, std, cov_diag, mean_and_cov, marginals, rand,
         logpdf, elbo, dtc, posterior, approx_posterior, VFE, DTC, AbstractGP, sampleplot, 
         update_approx_posterior
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using AbstractGPs
 using AbstractGPs: AbstractGP, MeanFunction, FiniteGP, ConstMean, GP, ZeroMean, 
-ConstMean, CustomMean, Xt_A_X, Xt_A_Y, Xt_invA_Y, Xt_invA_X, diag_At_A, diag_At_B, 
-diag_Xt_A_X, diag_Xt_A_Y, diag_Xt_invA_X, diag_Xt_invA_Y, Xtinv_A_Xinv, tr_At_A
+    ConstMean, CustomMean, Xt_A_X, Xt_A_Y, Xt_invA_Y, Xt_invA_X, diag_At_A, diag_At_B, 
+    diag_Xt_A_X, diag_Xt_A_Y, diag_Xt_invA_X, diag_Xt_invA_Y, Xtinv_A_Xinv, tr_At_A,
+    mean_and_cov_diag
 using Documenter
 using Distributions: MvNormal, PDMat
 using KernelFunctions


### PR DESCRIPTION
`mean_and_cov_diag` is currently exported, but it shouldn't be. The level at which users are intended to operate is the `FiniteGP` level, not the `AbstractGP` level. For example:
```julia
AbstractGPs.mean_and_cov_diag(f, x)
```
is not the intended use, rather
```julia
marginals(f(x))
```
is what is intended.

@theogf does this resolve #17? The README example actually already shows this use case correctly, but hopefully this will dissuade users against using this version.