### PR TITLE
Added option for using matrices with FiniteGP

### DIFF
--- a/src/abstract_gp/finite_gp.jl
+++ b/src/abstract_gp/finite_gp.jl
@@ -6,7 +6,7 @@ Gaussian noise with zero mean and covariance matrix `Σ`
 """
 struct FiniteGP{Tf<:AbstractGP, Tx<:AbstractVector, TΣ} <: ContinuousMultivariateDistribution
     f::Tf
-    x::Tx 
+    x::Tx
     Σy::TΣ
 end
 
@@ -17,6 +17,14 @@ end
 FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real) = FiniteGP(f, x, Fill(σ², length(x)))
 
 FiniteGP(f::AbstractGP, x::AbstractVector) = FiniteGP(f, x, 1e-18)
+
+function FiniteGP(
+    f::AbstractGP,
+    X::AbstractMatrix;
+    obsdim::Int = KernelFunctions.defaultobs,
+)
+    FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim))
+end
 
 Base.length(f::FiniteGP) = length(f.x)
 

--- a/src/abstract_gp/finite_gp.jl
+++ b/src/abstract_gp/finite_gp.jl
@@ -23,7 +23,7 @@ function FiniteGP(
     X::AbstractMatrix;
     obsdim::Int = KernelFunctions.defaultobs,
 )
-    FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim))
+    return FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim))
 end
 
 Base.length(f::FiniteGP) = length(f.x)

--- a/test/abstract_gp/finite_gp.jl
+++ b/test/abstract_gp/finite_gp.jl
@@ -9,12 +9,17 @@ end
     @testset "statistics" begin
         rng, N, N′ = MersenneTwister(123456), 1, 9
         x, x′, Σy, Σy′ = randn(rng, N), randn(rng, N′), zeros(N, N), zeros(N′, N′)
+        Xmat = randn(rng, N, N′)
+        Xvec = collect(eachcol(Xmat))
         f = GP(sin, SqExponentialKernel())
         fx, fx′ = FiniteGP(f, x, Σy), FiniteGP(f, x′, Σy′)
 
+        @test FiniteGP(f, Xmat, obsdim=1) == FiniteGP(f, RowVecs(Xmat))
+        @test FiniteGP(f, Xmat, obsdim=2) == FiniteGP(f, ColVecs(Xmat))
         @test mean(fx) == mean(f, x)
         @test cov(fx) == cov(f, x)
         @test cov(fx, fx′) == cov(f, x, x′)
+        @test cov(FiniteGP(f, Xmat, obsdim=2)) ≈ cov(f(Xvec))
         @test mean.(marginals(fx)) == mean(f(x))
         @test var.(marginals(fx)) == cov_diag(f, x)
         @test std.(marginals(fx)) == sqrt.(cov_diag(f, x))

--- a/test/abstract_gp/finite_gp.jl
+++ b/test/abstract_gp/finite_gp.jl
@@ -10,7 +10,6 @@ end
         rng, N, N′ = MersenneTwister(123456), 1, 9
         x, x′, Σy, Σy′ = randn(rng, N), randn(rng, N′), zeros(N, N), zeros(N′, N′)
         Xmat = randn(rng, N, N′)
-        Xvec = collect(eachcol(Xmat))
         f = GP(sin, SqExponentialKernel())
         fx, fx′ = FiniteGP(f, x, Σy), FiniteGP(f, x′, Σy′)
 
@@ -19,7 +18,6 @@ end
         @test mean(fx) == mean(f, x)
         @test cov(fx) == cov(f, x)
         @test cov(fx, fx′) == cov(f, x, x′)
-        @test cov(FiniteGP(f, Xmat, obsdim=2)) ≈ cov(f(Xvec))
         @test mean.(marginals(fx)) == mean(f(x))
         @test var.(marginals(fx)) == cov_diag(f, x)
         @test std.(marginals(fx)) == sqrt.(cov_diag(f, x))
@@ -273,7 +271,7 @@ end
 #             (Exp(), "Exp", 1e-6, 1e-6),
 #         ],
 #         [(
-#             k(α=α, β=β, l=l), 
+#             k(α=α, β=β, l=l),
 #             "$k_name(α=$(__foo(α)), β=$(__foo(β)), l=$(__foo(l)))",
 #             1e-6,
 #             1e-6,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ diag_Xt_A_X, diag_Xt_A_Y, diag_Xt_invA_X, diag_Xt_invA_Y, Xtinv_A_Xinv, tr_At_A
 using Documenter
 using Distributions: MvNormal, PDMat
 using KernelFunctions
-using KernelFunctions: Kernel
+using KernelFunctions: Kernel, ColVecs, RowVecs
 using LinearAlgebra
 using LinearAlgebra: AbstractTriangular
 using Random


### PR DESCRIPTION
This should fix #12, by respecting the convention of KernelFunctions.jl