### PR TITLE
Reexport KernelFunctions.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -17,4 +18,5 @@ Distributions = "0.19, 0.20, 0.21, 0.22, 0.23"
 FillArrays = "0.7, 0.8"
 KernelFunctions = "0.4"
 RecipesBase = "1"
+Reexport = "0.2"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -3,12 +3,12 @@ module AbstractGPs
     using Distributions
     using FillArrays
     using LinearAlgebra
-    using KernelFunctions
+    @reexport using KernelFunctions
     using Random
     using Statistics
 
     export GP, mean, cov, std, cov_diag, mean_and_cov, mean_and_cov_diag, marginals, rand,
-        logpdf, elbo, dtc, posterior, approx_posterior, VFE, DTC, AbstractGP, sampleplot, 
+        logpdf, elbo, dtc, posterior, approx_posterior, VFE, DTC, AbstractGP, sampleplot,
         update_approx_posterior
 
     # Various bits of utility functionality.

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -3,6 +3,7 @@ module AbstractGPs
     using Distributions
     using FillArrays
     using LinearAlgebra
+    using Reexport
     @reexport using KernelFunctions
     using Random
     using Statistics


### PR DESCRIPTION
Fixes #19
One possible issue is that all the kernel functions (`kernelmatrix` etc) are exported as well, which is not really needed. 
@devmotion @willtebbutt I could also refine the PR to only reexport all the `Kernel` constructors.