### PR TITLE
Move LatentGP to AbstractGPs.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -27,6 +27,9 @@ module AbstractGPs
     include(joinpath("posterior_gp", "posterior_gp.jl"))
     include(joinpath("posterior_gp", "approx_posterior_gp.jl"))
 
+    # LatentGP object to accomodate GPs with non-gaussian likelihoods.
+    include(joinpath("latent_gp", "latent_gp.jl"))
+
     # Plotting utilities.
     include(joinpath("util", "plotting.jl"))
 end # module

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -10,7 +10,7 @@ module AbstractGPs
 
     export GP, mean, cov, std, cov_diag, mean_and_cov, marginals, rand,
         logpdf, elbo, dtc, posterior, approx_posterior, VFE, DTC, AbstractGP, sampleplot,
-        update_approx_posterior
+        update_approx_posterior, LatentGP
 
     # Various bits of utility functionality.
     include(joinpath("util", "common_covmat_ops.jl"))

--- a/src/latent_gp/latent_gp.jl
+++ b/src/latent_gp/latent_gp.jl
@@ -1,0 +1,30 @@
+"""
+    LatentGP(f<:GP, lik)
+
+ - `fx` is a `FiniteGP`.
+ - `lik` is the log likelihood function which maps sample from f to corresposing 
+ conditional likelihood distributions.
+    
+"""
+struct LatentGP{T<:AbstractGPs.FiniteGP, S}
+    fx::T
+    lik::S
+end
+
+function Distributions.rand(rng::AbstractRNG, lgp::LatentGP)
+    f = rand(rng, lgp.fx)
+    y = rand(rng, lgp.lik(f))
+    return (f=f, y=y)
+end
+
+"""
+    logpdf(lgp::LatentGP, y::NamedTuple{(:f, :y)})
+
+```math
+    log p(y, f; x)
+```
+Returns the joint log density of the gaussian process output `f` and real output `y`.
+"""
+function Distributions.logpdf(lgp::LatentGP, y::NamedTuple{(:f, :y)})
+    return logpdf(lgp.fx, y.f) + logpdf(lgp.lik(y.f), y.y)
+end

--- a/test/latent_gp/latent_gp.jl
+++ b/test/latent_gp/latent_gp.jl
@@ -1,0 +1,15 @@
+@testset "latent_gp" begin
+    gp = GP(SqExponentialKernel())
+    x = rand(10)
+    y = rand(10)
+    fx = gp(x, 1e-5)
+
+    lik = GaussianLikelihood(1e-5)
+    
+    lgp = LatentGP(fx, lik)
+    @test typeof(lgp) <: LatentGP
+    @test typeof(lgp.fx) <: AbstractGPs.FiniteGP
+    f = rand(10)
+    @test typeof(logpdf(lgp, (f=f, y=y))) <: Real
+    @test typeof(rand(lgp)) <: NamedTuple{(:f, :y)}
+end

--- a/test/latent_gp/latent_gp.jl
+++ b/test/latent_gp/latent_gp.jl
@@ -3,10 +3,8 @@
     x = rand(10)
     y = rand(10)
     fx = gp(x, 1e-5)
-
-    lik = GaussianLikelihood(1e-5)
     
-    lgp = LatentGP(fx, lik)
+    lgp = LatentGP(fx, x -> MvNormal(x, 0.1))
     @test typeof(lgp) <: LatentGP
     @test typeof(lgp.fx) <: AbstractGPs.FiniteGP
     f = rand(10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,8 @@ include("test_util.jl")
         include(joinpath("posterior_gp", "approx_posterior_gp.jl"))
     end
 
+    include(joinpath("latent_gp", "latent_gp.jl"))
+
     include(joinpath("util", "plotting.jl"))
     
     @testset "doctests" begin


### PR DESCRIPTION
As discussed in [LatentGPs#4](https://github.com/JuliaGaussianProcesses/LatentGPs.jl/issues/4), this PR moves `LatentGP` to `AbstractGPs.jl`. 
