### PR TITLE
Refactor LatentGPs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/latent_gp/latent_gp.jl
+++ b/src/latent_gp/latent_gp.jl
@@ -7,10 +7,10 @@
  - `Σy` is the observation noise
     
 """
-struct LatentGP{T<:AbstractGPs.AbstractGP,S,E}
-    f::T
-    lik::S
-    Σy::E
+struct LatentGP{Tf<:AbstractGPs.AbstractGP,Tlik,TΣy}
+    f::Tf
+    lik::Tlik
+    Σy::TΣy
 end
 
 
@@ -22,9 +22,9 @@ end
  conditional likelihood distributions.
     
 """
-struct LatentFiniteGP{T<:AbstractGPs.FiniteGP,S}
-    fx::T
-    lik::S
+struct LatentFiniteGP{Tfx<:AbstractGPs.FiniteGP,Tlik}
+    fx::Tfx
+    lik::Tlik
 end
 
 (lgp::LatentGP)(x) = LatentFiniteGP(lgp.f(x, lgp.Σy), lgp.lik)

--- a/src/latent_gp/latent_gp.jl
+++ b/src/latent_gp/latent_gp.jl
@@ -1,30 +1,48 @@
 """
-    LatentGP(f<:GP, lik)
+    LatentGP(f<:GP, lik, Σy)
+
+ - `f` is a `AbstractGP`.
+ - `lik` is the log likelihood function which maps sample from f to corresposing 
+ conditional likelihood distributions.
+ - `Σy` is the observation noise
+    
+"""
+struct LatentGP{T<:AbstractGPs.AbstractGP,S,E}
+    f::T
+    lik::S
+    Σy::E
+end
+
+
+"""
+    LatentFiniteGP(fx<:FiniteGP, lik)
 
  - `fx` is a `FiniteGP`.
  - `lik` is the log likelihood function which maps sample from f to corresposing 
  conditional likelihood distributions.
     
 """
-struct LatentGP{T<:AbstractGPs.FiniteGP, S}
+struct LatentFiniteGP{T<:AbstractGPs.FiniteGP,S}
     fx::T
     lik::S
 end
 
-function Distributions.rand(rng::AbstractRNG, lgp::LatentGP)
-    f = rand(rng, lgp.fx)
-    y = rand(rng, lgp.lik(f))
+(lgp::LatentGP)(x) = LatentFiniteGP(lgp.f(x, lgp.Σy), lgp.lik)
+
+function Distributions.rand(rng::AbstractRNG, lfgp::LatentFiniteGP)
+    f = rand(rng, lfgp.fx)
+    y = rand(rng, lfgp.lik(f))
     return (f=f, y=y)
 end
 
 """
-    logpdf(lgp::LatentGP, y::NamedTuple{(:f, :y)})
+    logpdf(lfgp::LatentFiniteGP, y::NamedTuple{(:f, :y)})
 
 ```math
     log p(y, f; x)
 ```
 Returns the joint log density of the gaussian process output `f` and real output `y`.
 """
-function Distributions.logpdf(lgp::LatentGP, y::NamedTuple{(:f, :y)})
-    return logpdf(lgp.fx, y.f) + logpdf(lgp.lik(y.f), y.y)
+function Distributions.logpdf(lfgp::LatentFiniteGP, y::NamedTuple{(:f, :y)})
+    return logpdf(lfgp.fx, y.f) + logpdf(lfgp.lik(y.f), y.y)
 end

--- a/src/latent_gp/latent_gp.jl
+++ b/src/latent_gp/latent_gp.jl
@@ -7,7 +7,7 @@
  - `Σy` is the observation noise
     
 """
-struct LatentGP{Tf<:AbstractGPs.AbstractGP,Tlik,TΣy}
+struct LatentGP{Tf<:AbstractGP, Tlik, TΣy}
     f::Tf
     lik::Tlik
     Σy::TΣy
@@ -22,7 +22,7 @@ end
  conditional likelihood distributions.
     
 """
-struct LatentFiniteGP{Tfx<:AbstractGPs.FiniteGP,Tlik}
+struct LatentFiniteGP{Tfx<:FiniteGP, Tlik}
     fx::Tfx
     lik::Tlik
 end

--- a/test/latent_gp/latent_gp.jl
+++ b/test/latent_gp/latent_gp.jl
@@ -2,12 +2,16 @@
     gp = GP(SqExponentialKernel())
     x = rand(10)
     y = rand(10)
-    fx = gp(x, 1e-5)
     
-    lgp = LatentGP(fx, x -> MvNormal(x, 0.1))
+    lgp = LatentGP(gp, x -> MvNormal(x, 0.1), 1e-5)
     @test typeof(lgp) <: LatentGP
-    @test typeof(lgp.fx) <: AbstractGPs.FiniteGP
+    @test typeof(lgp.f) <: AbstractGPs.AbstractGP
+    @test typeof(lgp.Σy) <: Real
+
+    lfgp = lgp(x)
+    @test typeof(lfgp) <: AbstractGPs.LatentFiniteGP
+    @test typeof(lfgp.fx) <: AbstractGPs.FiniteGP
     f = rand(10)
-    @test typeof(logpdf(lgp, (f=f, y=y))) <: Real
-    @test typeof(rand(lgp)) <: NamedTuple{(:f, :y)}
+    @test typeof(logpdf(lfgp, (f=f, y=y))) <: Real
+    @test typeof(rand(lfgp)) <: NamedTuple{(:f, :y)}
 end

--- a/test/latent_gp/latent_gp.jl
+++ b/test/latent_gp/latent_gp.jl
@@ -4,14 +4,15 @@
     y = rand(10)
     
     lgp = LatentGP(gp, x -> MvNormal(x, 0.1), 1e-5)
-    @test typeof(lgp) <: LatentGP
-    @test typeof(lgp.f) <: AbstractGPs.AbstractGP
-    @test typeof(lgp.Σy) <: Real
+    @test lgp isa LatentGP
+    @test lgp.f isa AbstractGPs.AbstractGP
+    @test lgp.Σy isa Real
 
     lfgp = lgp(x)
-    @test typeof(lfgp) <: AbstractGPs.LatentFiniteGP
-    @test typeof(lfgp.fx) <: AbstractGPs.FiniteGP
+    @test lfgp isa AbstractGPs.LatentFiniteGP
+    @test lfgp.fx isa AbstractGPs.FiniteGP
+    
     f = rand(10)
-    @test typeof(logpdf(lfgp, (f=f, y=y))) <: Real
-    @test typeof(rand(lfgp)) <: NamedTuple{(:f, :y)}
+    @test logpdf(lfgp, (f=f, y=y)) isa Real
+    @test rand(lfgp) isa NamedTuple{(:f, :y)}
 end


### PR DESCRIPTION
This PR implements changes discussed in https://github.com/JuliaGaussianProcesses/LatentGPs.jl/issues/4. Particularly, [this comment](https://github.com/JuliaGaussianProcesses/LatentGPs.jl/issues/4#issuecomment-636327748) by @willtebbutt. 

- Renames `LatentGP` to `LatentFiniteGP`
- Introduces a redefined `LatentGP` which comprises of the `GP`, the likelihood and observation noise and not the inputs `x`.
