### PR TITLE
Passing noise for matrix case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/abstract_gp/finite_gp.jl
+++ b/src/abstract_gp/finite_gp.jl
@@ -16,19 +16,10 @@ end
 
 const default_σ² = 1e-18
 
-FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real) = FiniteGP(f, x, Fill(σ², length(x)))
-
-FiniteGP(f::AbstractGP, x::AbstractVector) = FiniteGP(f, x, default_σ²)
+FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real=default_σ²) = FiniteGP(f, x, Fill(σ², length(x)))
 
 function FiniteGP(
-    f::AbstractGP, X::AbstractMatrix;
-    obsdim::Int = KernelFunctions.defaultobs
-    )
-    return FiniteGP(f, X, default_σ²; obsdim=obsdim)
-end
-
-function FiniteGP(
-    f::AbstractGP, X::AbstractMatrix, σ²::Real;
+    f::AbstractGP, X::AbstractMatrix, σ²=default_σ²;
     obsdim::Int = KernelFunctions.defaultobs,
 )
     return FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim), σ²)

--- a/src/abstract_gp/finite_gp.jl
+++ b/src/abstract_gp/finite_gp.jl
@@ -14,16 +14,24 @@ function FiniteGP(f::AbstractGP, x::AbstractVector, σ²::AbstractVector{<:Real}
     return FiniteGP(f, x, Diagonal(σ²))
 end
 
+const default_σ² = 1e-18
+
 FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real) = FiniteGP(f, x, Fill(σ², length(x)))
 
-FiniteGP(f::AbstractGP, x::AbstractVector) = FiniteGP(f, x, 1e-18)
+FiniteGP(f::AbstractGP, x::AbstractVector) = FiniteGP(f, x, default_σ²)
 
 function FiniteGP(
-    f::AbstractGP,
-    X::AbstractMatrix;
+    f::AbstractGP, X::AbstractMatrix;
+    obsdim::Int = KernelFunctions.defaultobs
+    )
+    return FiniteGP(f, X, default_σ²; obsdim=obsdim)
+end
+
+function FiniteGP(
+    f::AbstractGP, X::AbstractMatrix, σ²::Real;
     obsdim::Int = KernelFunctions.defaultobs,
 )
-    return FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim))
+    return FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim), σ²)
 end
 
 Base.length(f::FiniteGP) = length(f.x)

--- a/src/abstract_gp/finite_gp.jl
+++ b/src/abstract_gp/finite_gp.jl
@@ -16,7 +16,9 @@ end
 
 const default_σ² = 1e-18
 
-FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real=default_σ²) = FiniteGP(f, x, Fill(σ², length(x)))
+function FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real=default_σ²)
+    return FiniteGP(f, x, Fill(σ², length(x)))
+end
 
 function FiniteGP(
     f::AbstractGP, X::AbstractMatrix, σ²=default_σ²;

--- a/test/abstract_gp/finite_gp.jl
+++ b/test/abstract_gp/finite_gp.jl
@@ -9,12 +9,15 @@ end
     @testset "statistics" begin
         rng, N, N′ = MersenneTwister(123456), 1, 9
         x, x′, Σy, Σy′ = randn(rng, N), randn(rng, N′), zeros(N, N), zeros(N′, N′)
+        σ² = 1e-3
         Xmat = randn(rng, N, N′)
         f = GP(sin, SqExponentialKernel())
         fx, fx′ = FiniteGP(f, x, Σy), FiniteGP(f, x′, Σy′)
 
         @test FiniteGP(f, Xmat, obsdim=1) == FiniteGP(f, RowVecs(Xmat))
         @test FiniteGP(f, Xmat, obsdim=2) == FiniteGP(f, ColVecs(Xmat))
+        @test FiniteGP(f, Xmat, σ², obsdim=1) == FiniteGP(f, RowVecs(Xmat), σ²)
+        @test FiniteGP(f, Xmat, σ², obsdim=2) == FiniteGP(f, ColVecs(Xmat), σ²) 
         @test mean(fx) == mean(f, x)
         @test cov(fx) == cov(f, x)
         @test cov(fx, fx′) == cov(f, x, x′)


### PR DESCRIPTION
Following thread on Slack, it is not possible to pass a noise argument in FiniteGP when using a matrix, i.e. :
```
X = rand(3,1)
gp = GP(SqExponentialKernel())
FiniteGP(gp, X, 0.01)
```
Currently does not work. This PR aims at fixing this behaviour and add necessary tests to check it.