### PR TITLE
Don't export AbstractGP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.2.9"
+version = "0.2.10"
 
 
 [deps]

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -12,7 +12,7 @@ module AbstractGPs
     using KernelFunctions: ColVecs, RowVecs
 
     export GP, mean, cov, std, cov_diag, mean_and_cov, marginals, rand,
-        logpdf, elbo, dtc, posterior, approx_posterior, VFE, DTC, AbstractGP, sampleplot,
+        logpdf, elbo, dtc, posterior, approx_posterior, VFE, DTC, sampleplot,
         update_approx_posterior, LatentGP, ColVecs, RowVecs
 
     # Various bits of utility functionality.


### PR DESCRIPTION
Resolves #54 

I'm bumping the patch because we never intended to export `AbstractGP` in the first place, so this counts as a bug to my mind. I'm happy to bump the minor version if anyone strongly objects to this though.