### PR TITLE
Fix issues with the MeanFunctions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.13"
+version = "0.2.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -66,7 +66,7 @@ GP(kernel::Kernel) = GP(ZeroMean(), kernel)
 
 # AbstractGP interface implementation.
 
-Statistics.mean(f::GP, x::AbstractVector) = map(f.mean, x)
+Statistics.mean(f::GP, x::AbstractVector) = _map(f.mean, x)
 
 Statistics.cov(f::GP, x::AbstractVector) = kernelmatrix(f.kernel, x)
 

--- a/src/gp/mean_function.jl
+++ b/src/gp/mean_function.jl
@@ -7,11 +7,11 @@ Returns `zero(T)` everywhere.
 """
 struct ZeroMean{T<:Real} <: MeanFunction end
 
-Base.map(::ZeroMean{T}, x::AbstractVector) where {T} = zeros(T, length(x))
+_map(::ZeroMean{T}, x::AbstractVector) where {T} = zeros(T, length(x))
 
-function ChainRulesCore.rrule(::typeof(Base.map), m::ZeroMean, x::AbstractVector)
+function ChainRulesCore.rrule(::typeof(_map), m::ZeroMean, x::AbstractVector)
     map_ZeroMean_pullback(Δ) = (NO_FIELDS, NO_FIELDS, Zero())
-    return map(m, x), map_ZeroMean_pullback
+    return _map(m, x), map_ZeroMean_pullback
 end
 
 ZeroMean() = ZeroMean{Float64}()
@@ -26,7 +26,7 @@ struct ConstMean{T<:Real} <: MeanFunction
     c::T
 end
 
-Base.map(m::ConstMean, x::AbstractVector) = fill(m.c, length(x))
+_map(m::ConstMean, x::AbstractVector) = fill(m.c, length(x))
 
 
 """
@@ -39,4 +39,4 @@ struct CustomMean{Tf} <: MeanFunction
     f::Tf
 end
 
-Base.map(f::CustomMean, x::AbstractVector) = map(f.f, x)
+_map(f::CustomMean, x::AbstractVector) = map(f.f, x)

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -8,7 +8,7 @@
         x = collect(range(-1.0, 1.0; length=N))
         x′ = collect(range(-1.0, 1.0; length=N′))
 
-        @test mean(f, x) == map(m, x)
+        @test mean(f, x) == AbstractGPs._map(m, x)
         @test cov(f, x) == kernelmatrix(k, x)
         abstractgp_interface_tests(f, x, x′)
     end

--- a/test/gp/mean_functions.jl
+++ b/test/gp/mean_functions.jl
@@ -9,15 +9,15 @@
         f = ZeroMean{Float64}()
 
         for x in [x]
-            @test map(f, x) == zeros(size(x))
+            @test AbstractGPs._map(f, x) == zeros(size(x))
             # differentiable_mean_function_tests(f, randn(rng, P), x)
         end
 
         # Manually verify the ChainRule. Really, this should employ FiniteDifferences, but
         # currently ChainRulesTestUtils isn't up to handling this, so this will have to do
         # for now.
-        y, pb = rrule(map, f, x)
-        @test y == map(f, x)
+        y, pb = rrule(AbstractGPs._map, f, x)
+        @test y == AbstractGPs._map(f, x)
         Δmap, Δf, Δx = pb(randn(P))
         @test iszero(Δmap)
         @test iszero(Δf)
@@ -31,7 +31,7 @@
         m = ConstMean(c)
 
         for x in [x]
-            @test map(m, x) == fill(c, N)
+            @test AbstractGPs._map(m, x) == fill(c, N)
             # differentiable_mean_function_tests(m, randn(rng, N), x)
         end
     end
@@ -41,7 +41,7 @@
         foo_mean = x->sum(abs2, x)
         f = CustomMean(foo_mean)
 
-        @test map(f, x) == map(foo_mean, x)
+        @test AbstractGPs._map(f, x) == map(foo_mean, x)
         # differentiable_mean_function_tests(f, randn(rng, N), x)
     end
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -75,7 +75,7 @@ end
 Test _very_ basic consistency properties of the mean function `m`.
 """
 function mean_function_tests(m::MeanFunction, x::AbstractVector)
-    @test map(m, x) isa AbstractVector
+    @test AbstractGPs._map(m, x) isa AbstractVector
     @test length(ew(m, x)) == length(x)
 end
 


### PR DESCRIPTION
This PR fixes the issue described in #14.
Similarly to what have been done in KernelFunctions.jl it replaces `Base.map` by `_map` to avoid having Zygote rules overtaking the adjoints.