### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
I did not notice that the version bump in https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/pull/73 was already outdated and version 0.2.14 already exists. This PR updates the version number such that https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/pull/73 can be released.