### PR TITLE
Ensure documentation builds without error

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,7 +45,9 @@ makedocs(;
         "Home" => "index.md",
         "API" => "api.md",
         "Examples" => joinpath.("examples", filter(x -> endswith(x, ".md"), readdir(OUTPUT))),
-    ]
+    ],
+    strict=true,
+    checkdocs=:exports, 
 )
 
 deploydocs(;


### PR DESCRIPTION
This PR ensures that builds fail if doctests fail or docstrings are not included in the documentation.