### PR TITLE
Remove `Symmetric(::Diagonal)` type piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.19"
+version = "0.2.20"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/posterior_gp/posterior_gp.jl
+++ b/src/posterior_gp/posterior_gp.jl
@@ -20,7 +20,7 @@ where `m` and `k` are the mean function and kernel of `fx.f` respectively.
 """
 function posterior(fx::FiniteGP, y::AbstractVector{<:Real})
     m, C_mat = mean_and_cov(fx)
-    C = cholesky(Symmetric(C_mat))
+    C = cholesky(_symmetric(C_mat))
     δ = y - m
     α = C \ δ
     return PosteriorGP(fx.f, (α=α, C=C, x=fx.x, δ=δ))

--- a/src/util/common_covmat_ops.jl
+++ b/src/util/common_covmat_ops.jl
@@ -1,3 +1,15 @@
+# If a matrix is `Diagonal`, we generally don't need to wrap it in a `Symmetric`, because
+# it's already symmetric. This is used in a couple of places to avoid precisely this and
+# having to add specialised methods of e.g. `_cholesky` for complicated wrapped types.
+_symmetric(X) = Symmetric(X)
+_symmetric(X::Diagonal) = X
+
+# Small bit of indirection to work around a cholesky-related bug whereby the interaction
+# between `FillArrays` and `Diagonal` and `Cholesky` causes problems.
+_cholesky(X) = cholesky(X)
+function _cholesky(X::Diagonal{<:Real, <:FillArrays.AbstractFill})
+    return cholesky(Diagonal(collect(diag(X))))
+end
 
 """
      update_chol(chol::Cholesky, C12::AbstractMatrix, C22::AbstractMatrix)

--- a/test/abstract_gp/finite_gp.jl
+++ b/test/abstract_gp/finite_gp.jl
@@ -169,12 +169,6 @@ end
         #     atol=1e-8, rtol=1e-8,
         # )
 
-        # Supporting utility function.
-        @testset "_cholesky" begin
-            D = Diagonal(Fill(5.0, 10))
-            @test AbstractGPs._cholesky(D).U ≈ AbstractGPs._cholesky(collect(D)).U
-        end
-
         # Ensure that the elbo is close to the logpdf when appropriate.
         @test elbo(y, ŷ, fx) isa Real
         @test elbo(y, ŷ, fx) ≈ logpdf(y, ŷ)

--- a/test/posterior_gp/approx_posterior_gp.jl
+++ b/test/posterior_gp/approx_posterior_gp.jl
@@ -1,24 +1,8 @@
 @testset "approx_posterior_gp" begin
-
-    @testset "_symmetric" begin
-        @testset "Matrix" begin
-            X = randn(5, 5)
-            @test AbstractGPs._symmetric(X) isa Symmetric
-            @test collect(AbstractGPs._symmetric(X)) == collect(Symmetric(X))
-        end
-        @testset "Diagonal" begin
-            X = Diagonal(randn(5))
-            @test AbstractGPs._symmetric(X) isa Diagonal
-            @test collect(AbstractGPs._symmetric(X)) == collect(Symmetric(X))
-        end
-    end
-
     rng = MersenneTwister(123456)
     N_cond = 3
     N_a = 5
     N_b = 6
-
-    @test Symmetric(Diagonal(randn(rng, 5))) isa Diagonal
 
     # Specify prior.
     f = GP(sin, Matern32Kernel())

--- a/test/util/common_covmat_ops.jl
+++ b/test/util/common_covmat_ops.jl
@@ -1,4 +1,23 @@
 @testset "common_covmat_ops" begin
+    # Supporting utility functions.
+    @testset "_cholesky" begin
+        D = Diagonal(Fill(5.0, 10))
+        @test AbstractGPs._cholesky(D).U ≈ AbstractGPs._cholesky(collect(D)).U
+    end
+
+    @testset "_symmetric" begin
+        @testset "Matrix" begin
+            X = randn(5, 5)
+            @test AbstractGPs._symmetric(X) isa Symmetric
+            @test collect(AbstractGPs._symmetric(X)) == collect(Symmetric(X))
+        end
+        @testset "Diagonal" begin
+            X = Diagonal(randn(5))
+            @test AbstractGPs._symmetric(X) isa Diagonal
+            @test collect(AbstractGPs._symmetric(X)) == collect(Symmetric(X))
+        end
+    end
+
     @testset "update_chol" begin
         X = rand(5)
         y = rand(5)


### PR DESCRIPTION
As the name says, this removes some pretty severe type piracy. Instead I switched to `_symmetric` wherever it seems possible to operate with diagonal matrices, and moved the helper functions `_symmetric` and `_cholesky` and their tests to the `src/util` folder.