### PR TITLE
Update plot recipe and allow to specify independent `x` variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -8,6 +8,7 @@ module AbstractGPs
     @reexport using KernelFunctions
     using Random
     using Statistics
+    using RecipesBase
 
     using KernelFunctions: ColVecs, RowVecs
 

--- a/test/util/plotting.jl
+++ b/test/util/plotting.jl
@@ -1,21 +1,69 @@
 @testset "plotting" begin
-    
     x = rand(10)
     f = GP(SqExponentialKernel())
-    gp = f(x)
+    gp = f(x, 0.1)
+
     plt1 = sampleplot(gp, 10)
     @test plt1.n == 10
 
-    rec1 = RecipesBase.apply_recipe(Dict{Symbol, Any}(), gp)
-    @test rec1[1].args[1] ≈ x atol=1e-5
-    @test rec1[1].args[2] ≈ zero(x) atol=1e-5
+    # Check recipe dispatches for `FiniteGP`s
+    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), gp)
+    @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+    @test rec[1].args[1] == x
+    @test rec[1].args[2] == gp
+    @test isempty(rec[1].plotattributes) # no default attributes
 
-    rec2 = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, rand(10))
-    @test typeof(rec2[1].args[1]) <: AbstractGPs.FiniteGP
+    z = 1 .+ x
+    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), z, gp)
+    @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+    @test rec[1].args[1] == z
+    @test rec[1].args[2] == zero(x)
+    # 3 default attributes
+    attributes = rec[1].plotattributes
+    @test sort!(collect(keys(attributes))) == [:fillalpha, :linewidth, :ribbon]
+    @test attributes[:fillalpha] == 0.3
+    @test attributes[:linewidth] == 2
+    @test attributes[:ribbon] == sqrt.(cov_diag(gp))
 
-    rec3 = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, 0:0.01:1)
-    @test typeof(rec3[1].args[1]) <: AbstractGPs.FiniteGP
+    # Check recipe dispatches for `AbstractGP`s
+    # with `AbstractVector` and `AbstractRange`:
+    for x in (rand(10), 0:0.01:1)
+        rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, x)
+        @test length(rec) == 1 && length(rec[1].args) == 1 # one series with one argument
+        @test rec[1].args[1] isa AbstractGPs.FiniteGP
+        @test rec[1].args[1].x == x
+        @test rec[1].args[1].f == f
+        @test isempty(rec[1].plotattributes) # no default attributes
 
-    rec4 = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, 0, 1)
-    @test typeof(rec4[1].args[1]) <: AbstractGPs.FiniteGP
+        z = 1 .+ x
+        rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), z, f, x)
+        @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+        @test rec[1].args[1] == z
+        @test rec[1].args[2] isa AbstractGPs.FiniteGP
+        @test rec[1].args[2].x == x
+        @test rec[1].args[2].f == f
+        @test isempty(rec[1].plotattributes) # no default attributes
+    end
+
+    # with minimum and maximum:
+    xmin = rand()
+    xmax = 4 + rand()
+    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, xmin, xmax)
+    @test length(rec) == 1 && length(rec[1].args) == 1 # one series with one argument
+    @test rec[1].args[1] isa AbstractGPs.FiniteGP
+    @test rec[1].args[1].x == range(xmin, xmax; length=1_000)
+    @test rec[1].args[1].f == f
+    @test isempty(rec[1].plotattributes) # no default attributes
+
+    z = range(0, 1; length=1_000)
+    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), z, f, xmin, xmax)
+    @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+    @test rec[1].args[1] == z
+    @test rec[1].args[2] isa AbstractGPs.FiniteGP
+    @test rec[1].args[2].x == range(xmin, xmax; length=1_000)
+    @test rec[1].args[2].f == f
+    @test isempty(rec[1].plotattributes) # no default attributes
+
+    # Check dimensions
+    @test_throws DimensionMismatch plot(rand(5), gp)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/issues/113 without breaking existing plotting functionality.

I am not completely happy with the `AbstractGP` dispatches though. I think maybe the following breaking changes would be a bit more intuitive (even without the additional option to specify the `x` variables):
- change `plot(gp::AbstractGP, x::AbstractVector)` to `plot(x, gp)` and forward it to `plot(x, gp(x))`: the points `x` of the projection are used as the first variable in the plot
- remove `plot(gp::AbstractGP, xmin::Real, xmax::Real)`: IMO there's no clear advantage over specifying `x` directly and it seems inconsistent with the Plots ecosystem
- only add a dispatch for `plot(x::AbstractVector, gp::FiniteGP)` but not one for `plot(x::AbstractVector, gp::AbstractGP)`: IMO the use case of different points `x` and `gp.x` seems quite special and therefore it seems reasonable to keep the dispatches and plotting signatures simple and demand that users construct the `FiniteGP` object manually