### PR TITLE
Remove links to binder (since it's broken)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,18 +15,17 @@ ispath(OUTPUT) && rm(OUTPUT; recursive=true)
 # add links to binder and nbviewer below the first heading of level 1
 function preprocess(content)
     sub = s"""
-        \0
-        #
-        # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/examples/@__NAME__.ipynb)
-        # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/examples/@__NAME__.ipynb)
-    """
-    return replace(content, r"^# # [^\n]*"m => sub; count=1)
+\0
+#
+# [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/examples/@__NAME__.ipynb)
+"""
+    return replace(content, r"^# # .*$"m => sub; count=1)
 end
 
 for file in readdir(EXAMPLES; join=true)
     endswith(file, ".jl") || continue
     Literate.markdown(file, OUTPUT; documenter=true, preprocess=preprocess)
-    Literate.notebook(file, OUTPUT)
+    Literate.notebook(file, OUTPUT; documenter=true)
 end
 
 DocMeta.setdocmeta!(


### PR DESCRIPTION
Fixes https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/issues/101.

Maybe we should open a new issue regarding the organization of the examples - I imagine if more examples are added it would be nice to keep them in separate project environments to avoid package conflicts (or e.g. Turing holding back other packages).