### PR TITLE
Reorganize plotting commands

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/examples/regression_1d.jl
+++ b/examples/regression_1d.jl
@@ -62,7 +62,7 @@ scatter(
     title="posterior (default parameters)", label="Train Data",
 )
 scatter!(x_test, y_test; label="Test Data")
-plot!(p_fx, 0:0.001:1; label=false)
+plot!(0:0.001:1, p_fx; label=false)
 
 # ## Markov Chain Monte Carlo
 #
@@ -430,5 +430,5 @@ scatter(
     title="posterior (VI with sparse grid)", label="Train Data",
 )
 scatter!(x_test, y_test; label="Test Data")
-plot!(ap, 0:0.001:1; label=false)
+plot!(0:0.001:1, ap; label=false)
 vline!(logistic.(opt.minimizer[3:end]); label="Pseudo-points")

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -36,4 +36,7 @@ module AbstractGPs
 
     # Plotting utilities.
     include(joinpath("util", "plotting.jl"))
+
+    # Deprecations.
+    include("deprecations.jl")
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,33 @@
+@recipe function f(gp::AbstractGP, x::AbstractArray)
+    Base.depwarn(
+        "`plot(gp::AbstractGP, x::AbstractArray)` is deprecated, " *
+        "use `plot(x, gp)` instead.",
+        :apply_recipe,
+    )
+    return x, gp
+end
+@recipe function f(gp::AbstractGP, xmin::Real, xmax::Real)
+    Base.depwarn(
+        "`plot(gp::AbstractGP, xmin::Real, xmax::Real)` is deprecated, use " *
+        "`plot(range(xmin, xmax; length=1_000), gp)` instead.",
+        :apply_recipe,
+    )
+    return range(xmin, xmax; length=1_000), gp
+end
+
+@recipe function f(z::AbstractVector, gp::AbstractGP, x::AbstractArray)
+    Base.depwarn(
+        "`plot(z::AbstractVector, gp::AbstractGP, x::AbstractArray)` is deprecated, " *
+        "use `plot(z, gp(x))` instead.",
+        :apply_recipe,
+    )
+    return z, gp(x)
+end
+@recipe function f(z::AbstractVector, gp::AbstractGP, xmin::Real, xmax::Real)
+    Base.depwarn(
+        "`plot(z::AbstractVector, gp::AbstractGP, xmin::Real, xmax::Real)` is deprecated, " *
+        "use `plot(z, gp(range(xmin, xmax; length=1_000))` instead.",
+        :apply_recipe,
+    )
+    return z, gp(range(xmin, xmax; length=1_000))
+end

--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -3,12 +3,13 @@
 @recipe function f(x::AbstractVector, gp::FiniteGP)
     length(x) == length(gp.x) ||
         throw(DimensionMismatch("length of `x` and `gp.x` has to be equal"))
+    scale = pop!(plotattributes, :ribbon_scale, 1.0)::Float64
+    scale > 0.0 || error("`bandwidth` keyword argument must be non-negative")
 
     # compute marginals
     μ, σ2 = mean_and_cov_diag(gp)
-    σ = map(sqrt, σ2)
 
-    ribbon := σ
+    ribbon := scale .* sqrt.(σ2)
     fillalpha --> 0.3
     linewidth --> 2
     return x, μ

--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -3,7 +3,7 @@
 @recipe function f(x::AbstractVector, gp::FiniteGP)
     length(x) == length(gp.x) ||
         throw(DimensionMismatch("length of `x` and `gp.x` has to be equal"))
-    scale = pop!(plotattributes, :ribbon_scale, 1.0)::Float64
+    scale::Float64 = pop!(plotattributes, :ribbon_scale, 1.0)
     scale > 0.0 || error("`bandwidth` keyword argument must be non-negative")
 
     # compute marginals

--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -1,15 +1,8 @@
-@recipe f(gp::AbstractGP, x::AbstractArray) = gp(x)
-@recipe f(gp::AbstractGP, xmin::Real, xmax::Real) = gp(range(xmin, xmax; length=1_000))
-
-@recipe f(z::AbstractVector, gp::AbstractGP, x::AbstractArray) = (z, gp(x))
-@recipe function f(z::AbstractVector, gp::AbstractGP, xmin::Real, xmax::Real)
-    return (z, gp(range(xmin, xmax; length=1_000)))
-end
-
+@recipe f(x::AbstractVector, gp::AbstractGP) = gp(x)
 @recipe f(gp::FiniteGP) = (gp.x, gp)
-@recipe function f(z::AbstractVector, gp::FiniteGP)
-    length(z) == length(gp.x) ||
-        throw(DimensionMismatch("length of `z` and `gp.x` has to be equal"))
+@recipe function f(x::AbstractVector, gp::FiniteGP)
+    length(x) == length(gp.x) ||
+        throw(DimensionMismatch("length of `x` and `gp.x` has to be equal"))
 
     # compute marginals
     μ, σ2 = mean_and_cov_diag(gp)
@@ -18,7 +11,7 @@ end
     ribbon := σ
     fillalpha --> 0.3
     linewidth --> 2
-    return z, μ
+    return x, μ
 end
 
 """

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,41 @@
+@testset "deprecations" begin
+    x = rand(10)
+    f = GP(SqExponentialKernel())
+    gp = f(x, 0.1)
+
+    # with `AbstractVector` and `AbstractRange`:
+    for x in (rand(10), 0:0.01:1)
+        rec = @test_deprecated RecipesBase.apply_recipe(Dict{Symbol,Any}(), f, x)
+        @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+        @test rec[1].args[1] == x
+        @test rec[1].args[2] == f
+        @test isempty(rec[1].plotattributes) # no default attributes
+
+        z = 1 .+ x
+        rec = @test_deprecated RecipesBase.apply_recipe(Dict{Symbol,Any}(), z, f, x)
+        @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+        @test rec[1].args[1] == z
+        @test rec[1].args[2] isa AbstractGPs.FiniteGP
+        @test rec[1].args[2].x == x
+        @test rec[1].args[2].f == f
+        @test isempty(rec[1].plotattributes) # no default attributes
+    end
+
+    # with minimum and maximum:
+    xmin = rand()
+    xmax = 4 + rand()
+    rec = @test_deprecated RecipesBase.apply_recipe(Dict{Symbol,Any}(), f, xmin, xmax)
+    @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+    @test rec[1].args[1] == range(xmin, xmax; length=1_000)
+    @test rec[1].args[2] == f
+    @test isempty(rec[1].plotattributes) # no default attributes
+
+    z = range(0, 1; length=1_000)
+    rec = @test_deprecated RecipesBase.apply_recipe(Dict{Symbol,Any}(), z, f, xmin, xmax)
+    @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
+    @test rec[1].args[1] == z
+    @test rec[1].args[2] isa AbstractGPs.FiniteGP
+    @test rec[1].args[2].x == range(xmin, xmax; length=1_000)
+    @test rec[1].args[2].f == f
+    @test isempty(rec[1].plotattributes) # no default attributes
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,10 @@ include("test_util.jl")
     println(" ")
     @info "Ran latent_gp tests"
 
+    include("deprecations.jl")
+    println(" ")
+    @info "Ran deprecation tests"
+
     include("turing.jl")
     println(" ")
     @info "Ran Turing tests"

--- a/test/util/plotting.jl
+++ b/test/util/plotting.jl
@@ -28,41 +28,13 @@
     # Check recipe dispatches for `AbstractGP`s
     # with `AbstractVector` and `AbstractRange`:
     for x in (rand(10), 0:0.01:1)
-        rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, x)
+        rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), x, f)
         @test length(rec) == 1 && length(rec[1].args) == 1 # one series with one argument
         @test rec[1].args[1] isa AbstractGPs.FiniteGP
         @test rec[1].args[1].x == x
         @test rec[1].args[1].f == f
         @test isempty(rec[1].plotattributes) # no default attributes
-
-        z = 1 .+ x
-        rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), z, f, x)
-        @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
-        @test rec[1].args[1] == z
-        @test rec[1].args[2] isa AbstractGPs.FiniteGP
-        @test rec[1].args[2].x == x
-        @test rec[1].args[2].f == f
-        @test isempty(rec[1].plotattributes) # no default attributes
     end
-
-    # with minimum and maximum:
-    xmin = rand()
-    xmax = 4 + rand()
-    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), f, xmin, xmax)
-    @test length(rec) == 1 && length(rec[1].args) == 1 # one series with one argument
-    @test rec[1].args[1] isa AbstractGPs.FiniteGP
-    @test rec[1].args[1].x == range(xmin, xmax; length=1_000)
-    @test rec[1].args[1].f == f
-    @test isempty(rec[1].plotattributes) # no default attributes
-
-    z = range(0, 1; length=1_000)
-    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), z, f, xmin, xmax)
-    @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
-    @test rec[1].args[1] == z
-    @test rec[1].args[2] isa AbstractGPs.FiniteGP
-    @test rec[1].args[2].x == range(xmin, xmax; length=1_000)
-    @test rec[1].args[2].f == f
-    @test isempty(rec[1].plotattributes) # no default attributes
 
     # Check dimensions
     @test_throws DimensionMismatch plot(rand(5), gp)

--- a/test/util/plotting.jl
+++ b/test/util/plotting.jl
@@ -14,8 +14,12 @@
     @test isempty(rec[1].plotattributes) # no default attributes
 
     z = 1 .+ x
-    for kwargs in (Dict{Symbol, Any}(), Dict{Symbol, Any}(:ribbon_scale => rand()))
-        scale = get(kwargs, :ribbon_scale, 1.0)::Float64
+    for kwargs in (
+        Dict{Symbol, Any}(),
+        Dict{Symbol, Any}(:ribbon_scale => 3),
+        Dict{Symbol, Any}(:ribbon_scale => rand()),
+    )
+        scale = get(kwargs, :ribbon_scale, 1.0)
         rec = RecipesBase.apply_recipe(kwargs, z, gp)
         @test length(rec) == 1 && length(rec[1].args) == 2 # one series with two arguments
         @test rec[1].args[1] == z


### PR DESCRIPTION
This PR reorganizes plotting commands as suggested in https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/pull/118:
- `plot(x::AbstractVector, gp::FiniteGP)` plots `mean(gp)` vs `x` with a band of one standard deviation `sqrt.(cov_diag(gp))`
- `plot(gp::FiniteGP)` is forwarded to `plot(gp.x, gp)`
- `plot(x::AbstractVector, gp::AbstractGP)` is forwarded to `plot(gp(x))`

The following calls are deprecated:
- `plot(gp::AbstractGP, x::AbstractVector)` (replaced with `plot(x, gp)`)
- `plot(gp::AbstractGP, xmin::Real, xmax::Real)` (replaced with `plot(range(xmin, xmax; length=1_000), gp)`)
- `plot(z::AbstractVector, gp::AbstractGP, x::AbstractVector)` (replaced with `plot(z, gp(x))`)
- `plot(z::AbstractVector, gp::AbstractGP, xmin::Real, xmax::Real)` (replaced with `plot(z, gp(range(xmin, xmax; length=1_000)))`)