### PR TITLE
Make `sampleplot` consistent with `plot`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -20,7 +20,7 @@ ChainRulesCore = "0.9"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
 FillArrays = "0.7, 0.8, 0.9, 0.10, 0.11"
 KernelFunctions = "0.9"
-StatsBase = "0.33"
 RecipesBase = "1"
 Reexport = "0.2, 1"
+StatsBase = "0.33"
 julia = "1.3"

--- a/examples/regression_1d.jl
+++ b/examples/regression_1d.jl
@@ -235,7 +235,7 @@ plt = scatter(
 )
 scatter!(plt, x_test, y_test; label="Test Data")
 for p in samples[(end - 100):end]
-    sampleplot!(plt, gp_posterior(p)(0:0.02:1), 1)
+    sampleplot!(plt, 0:0.02:1, gp_posterior(p))
 end
 plt
 
@@ -312,7 +312,7 @@ plt = scatter(
 )
 scatter!(plt, x_test, y_test; label="Test Data")
 for p in samples[(end - 100):end]
-    sampleplot!(plt, gp_posterior(p)(0:0.02:1), 1)
+    sampleplot!(plt, 0:0.02:1, gp_posterior(p))
 end
 plt
 
@@ -371,7 +371,7 @@ plt = scatter(
 )
 scatter!(plt, x_test, y_test; label="Test Data")
 for p in samples[(end - 100):end]
-    sampleplot!(plt, gp_posterior(p)(0:0.02:1), 1)
+    sampleplot!(plt, 0:0.02:1, gp_posterior(p))
 end
 plt
 

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -28,7 +28,6 @@ export GP,
     approx_posterior,
     VFE,
     DTC,
-    sampleplot,
     update_approx_posterior,
     LatentGP,
     ColVecs,
@@ -54,4 +53,7 @@ include(joinpath("latent_gp", "latent_gp.jl"))
 
 # Plotting utilities.
 include(joinpath("util", "plotting.jl"))
+
+# Deprecations.
+include("deprecations.jl")
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,3 @@
+@deprecate sampleplot(gp::FiniteGP, n::Int; kwargs...) sampleplot(gp; samples=n, kwargs...)
+@deprecate sampleplot!(gp::FiniteGP, n::Int; kwargs...) sampleplot!(gp; samples=n, kwargs...)
+@deprecate sampleplot!(plt::RecipesBase.AbstractPlot, gp::FiniteGP, n::Int; kwargs...) sampleplot!(plt, gp; samples=n, kwargs...)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,7 @@
 @deprecate sampleplot(gp::FiniteGP, n::Int; kwargs...) sampleplot(gp; samples=n, kwargs...)
-@deprecate sampleplot!(gp::FiniteGP, n::Int; kwargs...) sampleplot!(gp; samples=n, kwargs...)
-@deprecate sampleplot!(plt::RecipesBase.AbstractPlot, gp::FiniteGP, n::Int; kwargs...) sampleplot!(plt, gp; samples=n, kwargs...)
+@deprecate sampleplot!(gp::FiniteGP, n::Int; kwargs...) sampleplot!(
+    gp; samples=n, kwargs...
+)
+@deprecate sampleplot!(plt::RecipesBase.AbstractPlot, gp::FiniteGP, n::Int; kwargs...) sampleplot!(
+    plt, gp; samples=n, kwargs...
+)

--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -16,35 +16,56 @@
 end
 
 """
-    sampleplot(GP::FiniteGP, samples)
+    sampleplot([x::AbstractVector, ]f::FiniteGP; samples=1)
 
-Plot samples from the given `FiniteGP`. Make sure to run `using Plots` before using this 
-function. 
+Plot samples from `f` versus `x` (default value: `f.x`).
+
+Make sure to run `using Plots` before using this function.
 
 # Example
 ```julia
 using Plots
-f = GP(SqExponentialKernel())
-sampleplot(f(rand(10)), 10; markersize=5)
+gp = GP(SqExponentialKernel())
+sampleplot(gp(rand(5)); samples=10, markersize=5)
 ```
-The given example plots 10 samples from the given `FiniteGP`. The `markersize` is modified
+The given example plots 10 samples from the projection of the GP `gp`. The `markersize` is modified
 from default of 0.5 to 5.
+
+---
+    sampleplot(x::AbstractVector, gp::AbstractGP; samples=1)
+
+Plot samples from the finite projection `gp(x, 1e-9)` versus `x`.
 """
-@userplot SamplePlot
-@recipe function f(sp::SamplePlot)
-    x = sp.args[1].x
-    f = sp.args[1].f
-    num_samples = sp.args[2]
-    @series begin
-        samples = rand(f(x, 1e-9), num_samples)
-        seriestype --> :line
-        linealpha --> 0.2
-        markershape --> :circle
-        markerstrokewidth --> 0.0
-        markersize --> 0.5
-        markeralpha --> 0.3
-        seriescolor --> "red"
-        label --> ""
-        x, samples
-    end
+@userplot struct SamplePlot{X<:AbstractVector,F<:FiniteGP}
+    x::X
+    f::F
 end
+
+# default constructor (recipe forwards arguments as tuple)
+SamplePlot((x, f)::Tuple{<:AbstractVector,<:FiniteGP}) = SamplePlot(x, f)
+
+# `FiniteGP`s without explicit `x`
+SamplePlot((f,)::Tuple{<:FiniteGP}) = SamplePlot((f.x, f))
+
+# `AbstractGP`s with explicit `x`
+# zero mean observation noise with variance 1e-9 to avoid numerical issues in
+# Cholesky decomposition
+SamplePlot((x, gp)::Tuple{<:AbstractVector,<:AbstractGP}) = SamplePlot((gp(x, 1e-9),))
+
+@recipe function f(sp::SamplePlot)
+    nsamples::Int = get(plotattributes, :samples, 1)
+    samples = rand(sp.f, nsamples)
+
+    # Set default attributes
+    seriestype --> :line
+    linealpha --> 0.2
+    markershape --> :circle
+    markerstrokewidth --> 0.0
+    markersize --> 0.5
+    markeralpha --> 0.3
+    seriescolor --> "red"
+    label --> ""
+
+    return sp.x, samples
+end
+

--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -68,4 +68,3 @@ SamplePlot((x, gp)::Tuple{<:AbstractVector,<:AbstractGP}) = SamplePlot((gp(x, 1e
 
     return sp.x, samples
 end
-

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,14 @@
+@testset "deprecations" begin
+    x = rand(10)
+    f = GP(SqExponentialKernel())
+    gp = f(x, 0.1)
+
+    plt = @test_deprecated sampleplot(gp, 10)
+    @test plt.n == 10
+
+    @test_deprecated sampleplot!(gp, 4)
+    @test plt.n == 14
+
+    @test_deprecated sampleplot!(Plots.current(), gp, 3)
+    @test plt.n == 17
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,10 @@ include("test_util.jl")
     println(" ")
     @info "Ran latent_gp tests"
 
+    include("deprecations.jl")
+    println(" ")
+    @info "Ran deprecation tests"
+
     include("turing.jl")
     println(" ")
     @info "Ran Turing tests"

--- a/test/util/plotting.jl
+++ b/test/util/plotting.jl
@@ -3,8 +3,14 @@
     f = GP(SqExponentialKernel())
     gp = f(x, 0.1)
 
-    plt1 = sampleplot(gp, 10)
+    plt1 = sampleplot(gp; samples=10)
     @test plt1.n == 10
+
+    plt2 = sampleplot(rand(10), gp; samples=5)
+    @test plt2.n == 5
+
+    plt3 = sampleplot(rand(7), f; samples=8)
+    @test plt3.n == 8
 
     # Check recipe dispatches for `FiniteGP`s
     rec = RecipesBase.apply_recipe(Dict{Symbol,Any}(), gp)

--- a/test/util/plotting.jl
+++ b/test/util/plotting.jl
@@ -3,14 +3,21 @@
     f = GP(SqExponentialKernel())
     gp = f(x, 0.1)
 
-    plt1 = sampleplot(gp; samples=10)
-    @test plt1.n == 10
+    z = rand(10)
+    plt1 = sampleplot(z, gp)
+    @test plt1.n == 1
+    @test plt1.series_list[1].plotattributes[:x] == sort(z)
 
-    plt2 = sampleplot(rand(10), gp; samples=5)
-    @test plt2.n == 5
+    plt2 = sampleplot(gp; samples=10)
+    @test plt2.n == 10
+    sort_x = sort(x)
+    @test all(series.plotattributes[:x] == sort_x for series in plt2.series_list)
 
-    plt3 = sampleplot(rand(7), f; samples=8)
+    z = rand(7)
+    plt3 = sampleplot(z, f; samples=8)
     @test plt3.n == 8
+    sort_z = sort(z)
+    @test all(series.plotattributes[:x] == sort_z for series in plt3.series_list)
 
     # Check recipe dispatches for `FiniteGP`s
     rec = RecipesBase.apply_recipe(Dict{Symbol,Any}(), gp)


### PR DESCRIPTION
This PR makes `sampleplot` consistent with `plot`. More precisely, it deprecates the current syntax `sampleplot(::FiniteGP, nsamples::Int; kwargs...)` and introduces
- `sampleplot(x::AbstractVector, gp::FiniteGP; samples=1, kwargs...)`
- `sampleplot(gp::FiniteGP; kwargs...) = sampleplot(gp.x, gp; kwargs...)`
- `sampleplot(x::AbstractVector, gp::AbstractGP; kwargs...) = sampleplot(x, gp(x, 1e-9); kwargs...)`

Here 1e-9 is used to avoid numerical issues when computing the Cholesky decomposition. The PR also fixes a weirdness/bug in the current implementation: currently we do not sample from the provided `gp::FiniteGP` but from a modified `gp.f(gp.x, 1e-9)` (due to the same numerical issues I assume). With this PR instead sampling will performed from the provided `FiniteGP`.