### PR TITLE
Build stable docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+    tags: '*'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently new tags do not trigger the Docs action and therefore the stable docs are not updated.