### PR TITLE
Reference BayesianLinearRegressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ plot!(-0.5:0.001:1.5, p_fx; label="Posterior")
 ## Related Julia packages
 
 - [AbstractGPsMakie.jl](https://github.com/JuliaGaussianProcesses/AbstractGPsMakie.jl/) - Plotting GPs with [Makie.jl](https://github.com/JuliaPlots/Makie.jl/).
+- [BayesianLinearRegressors.jl](https://github.com/JuliaGaussianProcesses/BayesianLinearRegressors.jl) - Accelerated inference in GPs with a linear kernel. Built on types which implement this package's APIs.
 - [GPLikelihoods.jl](https://github.com/JuliaGaussianProcesses/GPLikelihoods.jl/) - Non-Gaussian likelihood functions to use with GPs.
 - [KernelFunctions.jl](https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/) - Kernel functions for machine learning.
 - [Stheno.jl](https://github.com/JuliaGaussianProcesses/Stheno.jl) - Building probabilistic programmes involving GPs. Built on types which implement this package's APIs.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -118,7 +118,7 @@ Existing implementations of this interface include
 1. [`WrappedGP`](https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/gp/gp.jl#L11)
 1. [`CompositeGP`](https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/composite/composite_gp.jl#L7)
 1. [`GaussianProcessProbabilisticProgramme`](https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/gaussian_process_probabilistic_programme.jl#L8)
-
+1. [`BayesianLinearRegressor`](https://github.com/JuliaGaussianProcesses/BayesianLinearRegressors.jl/blob/ea20b1bb0603d27c67b3751ad2cf26e271b7acaa/src/bayesian_linear_regression.jl#L11)
 
 #### Required Methods
 
@@ -158,6 +158,7 @@ _Do_ implement the [Primary Public API](@ref).
 Do _not_ implement the [Secondary Public API](@ref).
 
 [TemporalGPs.jl](https://github.com/JuliaGaussianProcesses/TemporalGPs.jl) is an example of a package that does this -- see the [`LTISDE`](https://github.com/JuliaGaussianProcesses/TemporalGPs.jl/blob/24343744cf60a50e09b301dee6f14b03cba7ccba/src/gp/lti_sde.jl#L7) implementation for an example.
+The same is true of the [`BayesianLinearRegressor`](https://github.com/JuliaGaussianProcesses/BayesianLinearRegressors.jl/blob/ea20b1bb0603d27c67b3751ad2cf26e271b7acaa/src/bayesian_linear_regression.jl#L11) type.
 
 
 


### PR DESCRIPTION
Since it now implements the AbstractGPs API, it seems reasonable to me to reference it here.