### PR TITLE
Revert mistaken docs entry (oops)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -118,7 +118,6 @@ Existing implementations of this interface include
 1. [`WrappedGP`](https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/gp/gp.jl#L11)
 1. [`CompositeGP`](https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/composite/composite_gp.jl#L7)
 1. [`GaussianProcessProbabilisticProgramme`](https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/gaussian_process_probabilistic_programme.jl#L8)
-1. [`BayesianLinearRegressor`](https://github.com/JuliaGaussianProcesses/BayesianLinearRegressors.jl/blob/ea20b1bb0603d27c67b3751ad2cf26e271b7acaa/src/bayesian_linear_regression.jl#L11)
 
 #### Required Methods
 


### PR DESCRIPTION
BayesianLinearRegressors absolutely does not implement the Internal AbstractGPs API -- this is what happens when I work late at night. It implements the Primary and Secondary Public APIs directly, so the remark at the bottom of this section is correct.