### PR TITLE
Support and test in-place sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -64,7 +64,7 @@ If you are building something on top of AbstractGPs, try to implement it in term
 
 ```@docs
 rand
-rand!
+Random.rand!
 marginals
 logpdf(::AbstractGPs.FiniteGP, ::AbstractVector{<:Real})
 posterior(::AbstractGPs.FiniteGP, ::AbstractVector{<:Real})

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -64,15 +64,16 @@ If you are building something on top of AbstractGPs, try to implement it in term
 
 ```@docs
 rand
+rand!
 marginals
 logpdf(::AbstractGPs.FiniteGP, ::AbstractVector{<:Real})
 posterior(::AbstractGPs.FiniteGP, ::AbstractVector{<:Real})
 mean(::AbstractGPs.FiniteGP)
 var(::AbstractGPs.FiniteGP)
-
 ```
 
 #### Optional methods
+
 Default implementations are provided for these, but you may wish to specialise for performance.
 ```@docs
 mean_and_var(::AbstractGPs.FiniteGP)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -64,7 +64,7 @@ If you are building something on top of AbstractGPs, try to implement it in term
 
 ```@docs
 rand
-Random.rand!
+rand!
 marginals
 logpdf(::AbstractGPs.FiniteGP, ::AbstractVector{<:Real})
 posterior(::AbstractGPs.FiniteGP, ::AbstractVector{<:Real})

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -14,6 +14,7 @@ using RecipesBase
 using KernelFunctions: ColVecs, RowVecs
 
 export GP,
+    rand!,
     mean,
     cov,
     var,

--- a/test/abstract_gp/finite_gp.jl
+++ b/test/abstract_gp/finite_gp.jl
@@ -48,6 +48,14 @@ end
         @test size(rand(rng, fx, 10)) == (length(x), 10)
         @test length(rand(fx)) == length(x)
         @test size(rand(fx, 10)) == (length(x), 10)
+
+        # Check that `rand!` calls do not error
+        y = similar(x)
+        rand!(rng, fx, y)
+        rand!(fx, y)
+        ys = similar(x, length(x), 10)
+        rand!(rng, fx, ys)
+        rand!(fx, ys)
     end
     @testset "rand (statistical)" begin
         rng = MersenneTwister(123456)
@@ -55,14 +63,19 @@ end
         m0 = 1
         S = 100_000
         x = range(-3.0, 3.0; length=N)
-        f = FiniteGP(GP(1, SqExponentialKernel()), x, 1e-12)
+        f = FiniteGP(GP(m0, SqExponentialKernel()), x, 1e-12)
 
         # Check mean + covariance estimates approximately converge for single-GP sampling.
-        f̂ = rand(rng, f, S)
-        @test maximum(abs.(mean(f̂; dims=2) - mean(f))) < 1e-2
+        f̂1 = rand(rng, f, S)
+        f̂2 = similar(f̂1)
+        rand!(rng, f, f̂2)
 
-        Σ′ = (f̂ .- mean(f)) * (f̂ .- mean(f))' ./ S
-        @test mean(abs.(Σ′ - cov(f))) < 1e-2
+        for f̂ in (f̂1, f̂2)
+            @test maximum(abs.(mean(f̂; dims=2) - mean(f))) < 1e-2
+
+            Σ′ = (f̂ .- mean(f)) * (f̂ .- mean(f))' ./ S
+            @test mean(abs.(Σ′ - cov(f))) < 1e-2
+        end
     end
     # @testset "rand (gradients)" begin
     #     rng, N, S = MersenneTwister(123456), 10, 3


### PR DESCRIPTION
Currently something like
```julia
julia> gp = GP(SqExponentialKernel());

julia> x = rand(11);

julia> rand!(f(x), similar(y))
```
throws an error since `Distributions._rand!` is not defined for `FiniteGP`s (this is the method that Distributions falls back to when one calls `rand!` for multivariate distributions and that one is supposed to define for new multivariate distributions: https://juliastats.org/Distributions.jl/latest/extends/#Multivariate-Sampler).

This PR adds a definition of `Distributions._rand!` for `FiniteGP`s. Distributions also falls back to it when calling `rand` but I think often this is a bad idea (one has to use type heuristics that fail sometimes - e.g. tests fail if one removes the custom definitions in AbstractGPs) and so I did not remove or modify the existing definitions of `rand`. It might still be useful to define `Distributions._rand!` instead of `Random.rand!` since then e.g. Distributions already checks if the size of the input is correct and one gets support for arrays of vectors for free (see https://github.com/JuliaStats/Distributions.jl/blob/a0cb0969d755872586ec79e985503f03beae9d08/src/multivariates.jl#L47-L66).