### PR TITLE
Revert "CompatHelper: bump compat for "FillArrays" to "0.12""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 ChainRulesCore = "0.10"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
-FillArrays = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12"
+FillArrays = "0.7, 0.8, 0.9, 0.10, 0.11"
 KernelFunctions = "0.9, 0.10"
 RecipesBase = "1"
 Reexport = "0.2, 1"


### PR DESCRIPTION
FillArrays 0.12 is not tested.