### PR TITLE
Only test stable Julia version on MacOS and Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,8 +29,10 @@ jobs:
             coverage: true
           - version: 1
             os: macOS-latest
+            arch: x64
           - version: 1
             os: windows-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,6 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
         include:
@@ -29,6 +27,10 @@ jobs:
             os: ubuntu-latest
             arch: x64
             coverage: true
+          - version: 1
+            os: macOS-latest
+          - version: 1
+            os: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,10 +24,6 @@ jobs:
           - x64
         include:
           - version: 1
-            os: ubuntu-latest
-            arch: x64
-            coverage: true
-          - version: 1
             os: macOS-latest
             arch: x64
           - version: 1
@@ -52,13 +48,13 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
-          coverage: ${{ matrix.coverage || false }}
+          coverage: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         env:
           GROUP: AbstractGPs
       - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.coverage
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
       - name: Send coverage
-        if: matrix.coverage
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v1
         with:
           file: lcov.info


### PR DESCRIPTION
As discussed in our meeting, this PR drops tests of Julia 1.3 on MacOS and Windows. Moreover, I also removed them from the nightly tests.

Fixes https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/issues/198.