### PR TITLE
RFC: Sketch of vector-valued GP functionality

### DIFF
--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -56,6 +56,9 @@ include("sparse_approximations.jl")
 # LatentGP and LatentFiniteGP objects to accommodate GPs with non-Gaussian likelihoods.
 include("latent_gp.jl")
 
+# GPs whose output is a vector.
+include("vector_valued_gp.jl")
+
 # Plotting utilities.
 include(joinpath("util", "plotting.jl"))
 

--- a/src/vector_valued_gp.jl
+++ b/src/vector_valued_gp.jl
@@ -73,3 +73,20 @@ function Distributions.logpdf(vx::FiniteVectorValuedGP, Y::AbstractMatrix{<:Real
     # Compute logpdf using FiniteGP.
     return logpdf(fx, y)
 end
+
+function posterior(vx::FiniteVectorValuedGP, Y::AbstractMatrix{<:Real})
+
+    # Construct equivalent FiniteGP.
+    x_f = KernelFunctions.MOInputIsotopicByOutputs(vx.x, vx.v.num_outputs)
+    f = vx.v.f
+    fx = f(x_f, vx.Σy)
+
+    # Construct flattened-version of observations.
+    y = vec(Y)
+
+    # Construct posterior AbstractGP
+    f_post = posterior(fx, y)
+
+    # Construct a new vector-valued GP.
+    return VectorValuedGP(f_post, vx.v.num_outputs)
+end

--- a/src/vector_valued_gp.jl
+++ b/src/vector_valued_gp.jl
@@ -1,0 +1,77 @@
+# Represents a GP whose output is vector-valued.
+struct VectorValuedGP{Tf<:AbstractGP}
+    f::Tf
+    num_outputs::Int
+end
+
+# I gave up figuring out how to properly subtype MatrixDistribution, but I want this to
+# subtype a distribution type which indicates that samples from this distribution produces
+# matrix of size num_features x num_outputs, or something like that.
+struct FiniteVectorValuedGP{Tv<:VectorValuedGP, Tx<:AbstractVector, TΣy<:Real}
+    v::Tv
+    x::Tx
+    Σy::TΣy
+end
+
+Base.length(f::FiniteVectorValuedGP) = length(f.x)
+
+(f::VectorValuedGP)(x...) = FiniteVectorValuedGP(f, x...)
+
+function Statistics.mean(vx::FiniteVectorValuedGP)
+
+    # Construct equivalent FiniteGP.
+    x_f = KernelFunctions.MOInputIsotopicByOutputs(vx.x, vx.v.num_outputs)
+    f = vx.v.f
+    fx = f(x_f, vx.Σy)
+
+    # Compute quantity under equivalent FiniteGP.
+    m = mean(fx)
+
+    # Construct the matrix-version of the quantity.
+    M = reshape(m, length(vx.x), vx.v.num_outputs)
+    return M
+end
+
+function Statistics.var(vx::FiniteVectorValuedGP)
+
+    # Construct equivalent FiniteGP.
+    x_f = KernelFunctions.MOInputIsotopicByOutputs(vx.x, vx.v.num_outputs)
+    f = vx.v.f
+    fx = f(x_f, vx.Σy)
+
+    # Compute quantity under equivalent FiniteGP.
+    v = var(fx)
+
+    # Construct the matrix-version of the quantity.
+    V = reshape(v, length(vx.x), vx.v.num_outputs)
+    return V
+end
+
+function Random.rand(rng::AbstractRNG, vx::FiniteVectorValuedGP)
+
+    # Construct equivalent FiniteGP.
+    x_f = KernelFunctions.MOInputIsotopicByOutputs(vx.x, vx.v.num_outputs)
+    f = vx.v.f
+    fx = f(x_f, vx.Σy)
+
+    # Compute quantity under equivalent FiniteGP.
+    y = rand(rng, fx)
+
+    # Construct the matrix-version of the quantity.
+    Y = reshape(y, length(vx.x), vx.v.num_outputs)
+    return Y
+end
+
+function Distributions.logpdf(vx::FiniteVectorValuedGP, Y::AbstractMatrix{<:Real})
+
+    # Construct equivalent FiniteGP.
+    x_f = KernelFunctions.MOInputIsotopicByOutputs(vx.x, vx.v.num_outputs)
+    f = vx.v.f
+    fx = f(x_f, vx.Σy)
+
+    # Construct flattened-version of observations.
+    y = vec(Y)
+
+    # Compute logpdf using FiniteGP.
+    return logpdf(fx, y)
+end

--- a/src/vector_valued_gp.jl
+++ b/src/vector_valued_gp.jl
@@ -7,7 +7,7 @@ end
 # I gave up figuring out how to properly subtype MatrixDistribution, but I want this to
 # subtype a distribution type which indicates that samples from this distribution produces
 # matrix of size num_features x num_outputs, or something like that.
-struct FiniteVectorValuedGP{Tv<:VectorValuedGP, Tx<:AbstractVector, TΣy<:Real}
+struct FiniteVectorValuedGP{Tv<:VectorValuedGP,Tx<:AbstractVector,TΣy<:Real}
     v::Tv
     x::Tx
     Σy::TΣy

--- a/src/vector_valued_gp.jl
+++ b/src/vector_valued_gp.jl
@@ -13,8 +13,6 @@ struct FiniteVectorValuedGP{Tv<:VectorValuedGP, Tx<:AbstractVector, TΣy<:Real}
     Σy::TΣy
 end
 
-Base.length(f::FiniteVectorValuedGP) = length(f.x)
-
 (f::VectorValuedGP)(x...) = FiniteVectorValuedGP(f, x...)
 
 function Statistics.mean(vx::FiniteVectorValuedGP)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,10 @@ include("test_util.jl")
         println(" ")
         @info "Ran latent_gp tests"
 
+        include("vector_valued_gp.jl")
+        println(" ")
+        @info "Ran vector_valued_gp tests"
+
         include("deprecations.jl")
         println(" ")
         @info "Ran deprecation tests"

--- a/test/vector_valued_gp.jl
+++ b/test/vector_valued_gp.jl
@@ -11,4 +11,6 @@
     rng = MersenneTwister(123456)
     Y = rand(rng, vx)
     logpdf(vx, Y)
+
+    v_post = posterior(vx, Y)
 end

--- a/test/vector_valued_gp.jl
+++ b/test/vector_valued_gp.jl
@@ -1,0 +1,14 @@
+@testset "vector_valued_gp" begin
+    f = GP(LinearMixingModelKernel([Matern52Kernel(), Matern12Kernel()], randn(2, 2)))
+    x = range(0.0, 10.0; length=3)
+    Σy = 0.1
+
+    v = AbstractGPs.VectorValuedGP(f, 2)
+    vx = v(x, Σy)
+
+    M = mean(vx)
+
+    rng = MersenneTwister(123456)
+    Y = rand(rng, vx)
+    logpdf(vx, Y)
+end


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->

What: Proposal for a vector-valued GP.

Why: It might be a convenient thing to have around for some use-cases in which people really do think about their multi-output GPs as being vector-valued. 

Why: it's easy to provide, because we already have the functionality, we just need to package it nicely.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

Add a vector-valued GP. Not proposing to export at this point in time, because I don't know what I even think about it.

<!-- A clear and concise description of the contents of this pull request. -->
Contains a sketch of the implementation in which the intent is hopefully clear. Does not contain proper testing, and I don't believe that the API is complete.


**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

I considered not bothering with this, and I still think that's a good option -- I really don't know whether or not I like this, but I can imagine that it would ease cognitive burden in some common workflows.

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->

No breaking changes.
