### PR TITLE
define Base.length(::LatentFiniteGP)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/latent_gp.jl
+++ b/src/latent_gp.jl
@@ -28,6 +28,8 @@ end
 
 (lgp::LatentGP)(x) = LatentFiniteGP(lgp.f(x, lgp.Σy), lgp.lik)
 
+Base.length(lgpx::LatentFiniteGP) = length(lgpx.fx)
+
 function Distributions.rand(rng::AbstractRNG, lfgp::LatentFiniteGP)
     f = rand(rng, lfgp.fx)
     y = rand(rng, lfgp.lik(f))

--- a/test/latent_gp.jl
+++ b/test/latent_gp.jl
@@ -11,6 +11,7 @@
     lfgp = lgp(x)
     @test lfgp isa AbstractGPs.LatentFiniteGP
     @test lfgp.fx isa AbstractGPs.FiniteGP
+    @test length(lfgp) == length(x)
 
     f = rand(10)
     @test logpdf(lfgp, (f=f, y=y)) isa Real


### PR DESCRIPTION
Just as there is `length(::FiniteGP)` - means we have to rely less on implementation details (the `fx` field) e.g. for dimension consistency checking.:)