### PR TITLE
Add conversion of `FiniteGP` to `MvNormal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/finite_gp_projection.jl
+++ b/src/finite_gp_projection.jl
@@ -26,6 +26,13 @@ function FiniteGP(
     return FiniteGP(f, KernelFunctions.vec_of_vecs(X; obsdim=obsdim), σ²)
 end
 
+## conversions
+Base.convert(::Type{MvNormal}, f::FiniteGP) = MvNormal(mean_and_cov(f)...)
+function Base.convert(::Type{MvNormal{T}}, f::FiniteGP) where {T}
+    μ, Σ = mean_and_cov(f)
+    return MvNormal(convert(AbstractArray{T}, μ), convert(AbstractArray{T}, Σ))
+end
+
 Base.length(f::FiniteGP) = length(f.x)
 
 (f::AbstractGP)(x...) = FiniteGP(f, x...)

--- a/test/finite_gp_projection.jl
+++ b/test/finite_gp_projection.jl
@@ -6,6 +6,22 @@ function generate_noise_matrix(rng::AbstractRNG, N::Int)
 end
 
 @testset "finite_gp" begin
+    @testset "convert" begin
+        f = GP(sin, SqExponentialKernel())
+        x = randn(10)
+        Σy = generate_noise_matrix(Random.GLOBAL_RNG, 10)
+        fx = FiniteGP(f, x, Σy)
+
+        dist = @inferred(convert(MvNormal, fx))
+        @test dist isa MvNormal{Float64}
+        @test mean(dist) ≈ mean(fx)
+        @test cov(dist) ≈ cov(fx)
+
+        dist = @inferred(convert(MvNormal{Float32}, fx))
+        @test dist isa MvNormal{Float32}
+        @test mean(dist) ≈ mean(fx)
+        @test cov(dist) ≈ cov(fx)
+    end
     @testset "statistics" begin
         rng, N, N′ = MersenneTwister(123456), 1, 9
         x, x′, Σy, Σy′ = randn(rng, N), randn(rng, N′), zeros(N, N), zeros(N′, N′)


### PR DESCRIPTION
Allows to convert a `FiniteGP` to a `MvNormal`. In some cases this could be useful to avoid repeated computations of the Cholesky decomposition of the covariance matrix.

Addresses https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/issues/232.
