### PR TITLE
remove superfluous _symmetric() calls

### DIFF
--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -51,7 +51,7 @@ Intelligence and Statistics. 2009.
 function posterior(vfe::VFE, fx::FiniteGP, y::AbstractVector{<:Real})
     @assert vfe.fz.f === fx.f
 
-    U_y = _cholesky(_symmetric(fx.Σy)).U
+    U_y = _cholesky(fx.Σy).U
     U = cholesky(_symmetric(cov(vfe.fz))).U
 
     B_εf = U' \ (U_y' \ cov(fx, vfe.fz))'
@@ -85,7 +85,7 @@ function update_posterior(
     U = f_post_approx.data.U
     z = inducing_points(f_post_approx)
 
-    U_y₂ = _cholesky(_symmetric(fx.Σy)).U
+    U_y₂ = _cholesky(fx.Σy).U
 
     temp = zeros(size(f_post_approx.data.Σy, 1), size(fx.Σy, 2))
     Σy = [f_post_approx.data.Σy temp; temp' fx.Σy]
@@ -136,7 +136,7 @@ function update_posterior(f_post_approx::ApproxPosteriorGP{<:VFE}, fz::FiniteGP)
     Cu1f = cov(f_post_approx.prior, z_old, f_post_approx.data.x)
     Cu2f = cov(f_post_approx.prior, z, f_post_approx.data.x)
 
-    U_y = _cholesky(_symmetric(f_post_approx.data.Σy)).U
+    U_y = _cholesky(f_post_approx.data.Σy).U
 
     B_εf₂ = U22' \ (Cu2f * inv(U_y) - U12' * B_εf₁)
     B_εf = vcat(B_εf₁, B_εf₂)


### PR DESCRIPTION
**Summary**
Remove `_symmetric()` calls on user-provided matrices that should be pos-def (and hence symmetric) already, as discussed in https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/pull/236#discussion_r738464168

**Proposed changes**
We use `_symmetric()` to ensure we can compute cholesky of matrices that _should_ be posdef (mathematically) but might not be (numerically, due to small rounding errors in matmul & co). This is the right thing to do for intermediate matrices, but when applied to user input directly, this risks just hiding mistakes. I.e., if a user provides an arbitrary (non-pos-def) matrix, it would simply mask the mistake, happily compute an answer (which will be misleading), instead of crashing & giving the user an indication that there's a mistake somewhere.

**What alternatives have you considered?**
We could add a check to `_symmetric` that the return value is approximately the same as the input. We could also explicitly check that the user input is symmetric (or nearly so), or enforce it to be some kind of PDMat type.

**Breaking changes**
I would consider this a bugfix, the only thing that would break is already-broken usage.