### PR TITLE
Update recommended audience for API docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,8 +2,8 @@
 
 ## Intended Audience
 
-This page is intended for developers.
-If you are a user, please refer to our other examples.
+This page is best read once you have a sense of what this package is trying to achieve.
+Therefore, we recommend reading (or at least skimming) some of the examples before reading these docs.
 
 
 


### PR DESCRIPTION
The docs previously suggested that they were only for developers. I don't really like warding people off from these docs because they're quite useful. So I'm proposing to change it to suggesting that people read around a little before reading them (I can't imagine anyone getting much out of them without having at least some sense of context).
