### PR TITLE
Improve `diag_At_A` and `diag_At_B` for vectors

### DIFF
--- a/src/util/common_covmat_ops.jl
+++ b/src/util/common_covmat_ops.jl
@@ -60,7 +60,8 @@ Xt_invA_Y(X::AbstractVecOrMat, A::Cholesky, Y::AbstractVecOrMat) = (A.U' \ X)' *
 
 At_A(A::AbstractVecOrMat) = A'A
 
-diag_At_A(A::AbstractVecOrMat) = vec(sum(abs2.(A); dims=1))
+diag_At_A(A::AbstractMatrix) = vec(sum(abs2.(A); dims=1))
+diag_At_A(x::AbstractVector) = [x'x]
 
 tr_At_A(A::AbstractVecOrMat) = sum(abs2, A)
 
@@ -72,6 +73,7 @@ function diag_At_B(A::AbstractVecOrMat, B::AbstractVecOrMat)
     )
     return vec(sum(A .* B; dims=1))
 end
+diag_At_B(x::AbstractVector, y::AbstractVector) = [x'y]
 
 diag_Xt_A_X(A::Cholesky, X::AbstractVecOrMat) = diag_At_A(A.U * X)
 


### PR DESCRIPTION

```julia
julia> using BenchmarkTools

julia> x = rand(5000); y = rand(5000);

# before
julia> @btime vec(sum(abs2.(x); dims=1));
  2.800 μs (6 allocations: 39.23 KiB)

julia> @btime vec(sum(x .* y; dims=1));
  2.391 μs (5 allocations: 39.23 KiB)

# after
julia> @btime [x'x];
  515.724 ns (3 allocations: 96 bytes)

julia> @btime [x'y];
  813.826 ns (3 allocations: 96 bytes)
```
