### PR TITLE
assert -> explicit throw

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -283,7 +283,7 @@ end
 function consistency_check(fx, y)
     length(fx) == length(y) || throw(
         DimensionMismatch(
-            "length(fx) = $(length(fx)) and length(y) = $(length(y)) must match"
+            "the dimension of the projected GP (here: $(length(fx))) must equal the number of targets (here: $(length(y)))"
         ),
     )
     return nothing

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -268,7 +268,12 @@ end
 
 # Factor out computations common to the `elbo` and `dtc`.
 function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::FiniteGP)
-    consistency_check(fx, y)
+    length(fx) == length(y) || throw(
+        DimensionMismatch(
+            "the dimension of the projected GP (here: $(length(fx))) must equal the number of targets (here: $(length(y)))",
+        ),
+    )
+
     chol_Σy = _cholesky(fx.Σy)
 
     A = cholesky(_symmetric(cov(fz))).U' \ (chol_Σy.U' \ cov(fx, fz))'
@@ -278,15 +283,6 @@ function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::Fin
     tmp = logdet(chol_Σy) + logdet(Λ_ε) + sum(abs2, δ) - sum(abs2, Λ_ε.U' \ (A * δ))
     _dtc = -(length(y) * typeof(tmp)(log2π) + tmp) / 2
     return _dtc, A
-end
-
-function consistency_check(fx, y)
-    length(fx) == length(y) || throw(
-        DimensionMismatch(
-            "the dimension of the projected GP (here: $(length(fx))) must equal the number of targets (here: $(length(y)))",
-        ),
-    )
-    return nothing
 end
 
 function tr_Cf_invΣy(f::FiniteGP, Σy::Diagonal)

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -283,7 +283,7 @@ end
 function consistency_check(fx, y)
     length(fx) == length(y) || throw(
         DimensionMismatch(
-            "the dimension of the projected GP (here: $(length(fx))) must equal the number of targets (here: $(length(y)))"
+            "the dimension of the projected GP (here: $(length(fx))) must equal the number of targets (here: $(length(y)))",
         ),
     )
     return nothing

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -281,7 +281,12 @@ function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::Fin
 end
 
 function consistency_check(fx, y)
-    @assert length(fx) == length(y)
+    length(fx) == length(y) || throw(
+        DimensionMismatch(
+            "length(fx) = $(length(fx)) and length(y) = $(length(y)) must match"
+        ),
+    )
+    return nothing
 end
 
 function tr_Cf_invΣy(f::FiniteGP, Σy::Diagonal)


### PR DESCRIPTION
**Summary**

Replace `@assert` with an explicit `throw()`.

**Follow-up question**

Should we also do the same for the prior consistency checks,
```julia
@assert vfe.fz.f === fx.f
```
could move those into `consistency_check` as well? (NB- `check_consistency` would seem to be a slightly more helpful name, functions-as-verbs, any objections to renaming it? it's meant as an internal function, not exported, so shouldn't break backwards compatibility, or would it?)