### PR TITLE
Test VFE with the naive implementation

### DIFF
--- a/test/sparse_approximations.jl
+++ b/test/sparse_approximations.jl
@@ -31,14 +31,24 @@
 
     u = randn(rng, 10)
     f_approx_post = posterior(VFE(f(u, 1e-12)), fx, y)
-    
-    q(a, b) = kernelmatrix(k, a, u) * inv(kernelmatrix(k, u, u)) * kernelmatrix(k, u, b)    
-    Σ(x, u) = inv(inv(f_approx_post.approx.fz.Σy) * kernelmatrix(k, u, x) * kernelmatrix(k, x, u) + kernelmatrix(k, u, u))
-    
-    @test inv(LinearAlgebra.Diagonal(1e-12*ones(5))) * kernelmatrix(k, x_test, u) * Σ(x, u) * kernelmatrix(k, u, x) * y ≈
-        mean(f_approx_post, x_test)
 
-    @test kernelmatrix(k, x_test, x_test) - q(x_test, x_test) + kernelmatrix(k, x_test, u) * Σ(x, u) * transpose(kernelmatrix(k, x_test, u)) ≈
+    q(a, b) = kernelmatrix(k, a, u) * inv(kernelmatrix(k, u, u)) * kernelmatrix(k, u, b)
+    function Σ(x, u)
+        return inv(
+            inv(f_approx_post.approx.fz.Σy) *
+            kernelmatrix(k, u, x) *
+            kernelmatrix(k, x, u) + kernelmatrix(k, u, u),
+        )
+    end
+
+    @test inv(LinearAlgebra.Diagonal(1e-12 * ones(5))) *
+          kernelmatrix(k, x_test, u) *
+          Σ(x, u) *
+          kernelmatrix(k, u, x) *
+          y ≈ mean(f_approx_post, x_test)
+
+    @test kernelmatrix(k, x_test, x_test) - q(x_test, x_test) +
+          kernelmatrix(k, x_test, u) * Σ(x, u) * transpose(kernelmatrix(k, x_test, u)) ≈
         cov(f_approx_post, x_test)
 
     @testset "update_posterior (new observation)" begin


### PR DESCRIPTION
**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->

We currently lack any test to confirm the predictive distribution is matching what is prescribed by the original papers - 
- VFE:  M. K. Titsias. "Variational learning of inducing variables in sparse Gaussian
processes". In: Proceedings of the Twelfth International Conference on Artificial
Intelligence and Statistics. 2009.
- DTC: M. Seeger, C. K. I. Williams and N. D. Lawrence. "Fast Forward Selection to Speed Up
Sparse Gaussian Process Regression". In: Proceedings of the Ninth International Workshop on
Artificial Intelligence and Statistics. 2003




This is an attempt at fixing that.

The predictive distribution for both DTC and VFE should be the same -- projected process (PP)? This PR is currently checking it against DTC's predictive distribution defined in [Quinonero-Candela's](https://www.jmlr.org/papers/volume6/quinonero-candela05a/quinonero-candela05a.pdf) Eq 20b

