### PR TITLE
revert change of FiniteGP constructor from #236 to avoid breaking downstream packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/finite_gp_projection.jl
+++ b/src/finite_gp_projection.jl
@@ -17,7 +17,7 @@ end
 const default_σ² = 1e-18
 
 function FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real=default_σ²)
-    return FiniteGP(f, x, ScalMat(length(x), σ²))
+    return FiniteGP(f, x, Fill(σ², length(x)))
 end
 
 ## conversions


### PR DESCRIPTION
The
```julia
FiniteGP(f::AbstractGP, x::AbstractVector, σ²::Real=default_σ²) = FiniteGP(f, x, ScalMat(length(x), σ²))
```
unfortunately ended up breaking ApproximateGPs, so this reverts that specific change of #236.

I'll move this constructor change into #306 instead.