### PR TITLE
Opt out of `rrule` for `mean`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.12"
+version = "0.5.13"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -18,6 +19,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+ChainRulesCore = "1"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 FillArrays = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
 IrrationalConstants = "0.1"

--- a/src/AbstractGPs.jl
+++ b/src/AbstractGPs.jl
@@ -14,6 +14,8 @@ using IrrationalConstants: log2π
 
 using KernelFunctions: ColVecs, RowVecs
 
+using ChainRulesCore: ChainRulesCore
+
 export GP,
     rand!,
     mean,

--- a/src/abstract_gp.jl
+++ b/src/abstract_gp.jl
@@ -18,6 +18,9 @@ Compute the mean vector of the multivariate Normal `f(x)`.
 """
 Statistics.mean(::AbstractGP, ::AbstractVector)
 
+# https://github.com/JuliaDiff/ChainRules.jl/pull/615 introduced a `rrule` that causes errors
+ChainRulesCore.@opt_out ChainRulesCore.rrule(::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode}, ::typeof(mean), ::AbstractGP, ::AbstractVector)
+
 """
     cov(f::AbstractGP, x::AbstractVector)
 

--- a/src/abstract_gp.jl
+++ b/src/abstract_gp.jl
@@ -19,7 +19,12 @@ Compute the mean vector of the multivariate Normal `f(x)`.
 Statistics.mean(::AbstractGP, ::AbstractVector)
 
 # https://github.com/JuliaDiff/ChainRules.jl/pull/615 introduced a `rrule` that causes errors
-ChainRulesCore.@opt_out ChainRulesCore.rrule(::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode}, ::typeof(mean), ::AbstractGP, ::AbstractVector)
+ChainRulesCore.@opt_out ChainRulesCore.rrule(
+    ::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode},
+    ::typeof(mean),
+    ::AbstractGP,
+    ::AbstractVector,
+)
 
 """
     cov(f::AbstractGP, x::AbstractVector)


### PR DESCRIPTION
https://github.com/JuliaDiff/ChainRules.jl/pull/615 broke AD since it captures also `mean(::AbstractGP, ::AbstractVector)`. Opting out of the specific rule seems to fix test errors locally.

cc @simsurace