### PR TITLE
Fixes #327, example documentation typo

### DIFF
--- a/examples/0-intro-1d/script.jl
+++ b/examples/0-intro-1d/script.jl
@@ -64,7 +64,7 @@ f = GP(Matern52Kernel())
 #md nothing #hide
 
 # We create a finite dimensional projection at the inputs of the training dataset
-# observed under Gaussian noise with standard deviation $\sigma = 0.1$, and compute the
+# observed under Gaussian noise with variance $\sigma^2 = 0.1$, and compute the
 # log-likelihood of the outputs of the training dataset.
 
 fx = f(x_train, 0.1)


### PR DESCRIPTION
**Summary**
Fixes #327 by fixing documentation typo to reflect API intention and produce expected results.

