### PR TITLE
Use non scalar method to compute logdet for cholesky and relax compat for PDMat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -24,7 +24,7 @@ Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 FillArrays = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
 IrrationalConstants = "0.1"
 KernelFunctions = "0.9, 0.10"
-PDMats = "0.11"
+PDMats = "0.10, 0.11"
 RecipesBase = "1"
 Reexport = "0.2, 1"
 StatsBase = "0.33"

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -266,7 +266,7 @@ function dtc(vfe::VFE, fx::FiniteGP, y::AbstractVector{<:Real})
     return _dtc
 end
 
-logdet_(C::Cholesky) = sum(log.(diag(C.factors)))
+logdet_(C::Cholesky) = 2 * sum(log, diag(C.factors))
 # Factor out computations common to the `elbo` and `dtc`.
 function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::FiniteGP)
     length(fx) == length(y) || throw(

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -267,6 +267,7 @@ function dtc(vfe::VFE, fx::FiniteGP, y::AbstractVector{<:Real})
 end
 
 logdet_(C::Cholesky) = 2 * sum(log, diag(C.factors))
+
 # Factor out computations common to the `elbo` and `dtc`.
 function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::FiniteGP)
     length(fx) == length(y) || throw(

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -266,6 +266,7 @@ function dtc(vfe::VFE, fx::FiniteGP, y::AbstractVector{<:Real})
     return _dtc
 end
 
+logdet_(C::Cholesky) = sum(diag(C.factors))
 # Factor out computations common to the `elbo` and `dtc`.
 function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::FiniteGP)
     length(fx) == length(y) || throw(
@@ -280,7 +281,7 @@ function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::Fin
     Λ_ε = cholesky(Symmetric(A * A' + I))
     δ = chol_Σy.U' \ (y - mean(fx))
 
-    tmp = logdet(chol_Σy) + logdet(Λ_ε) + sum(abs2, δ) - sum(abs2, Λ_ε.U' \ (A * δ))
+    tmp = logdet_(chol_Σy) + logdet_(Λ_ε) + sum(abs2, δ) - sum(abs2, Λ_ε.U' \ (A * δ))
     _dtc = -(length(y) * typeof(tmp)(log2π) + tmp) / 2
     return _dtc, A
 end

--- a/src/sparse_approximations.jl
+++ b/src/sparse_approximations.jl
@@ -266,7 +266,7 @@ function dtc(vfe::VFE, fx::FiniteGP, y::AbstractVector{<:Real})
     return _dtc
 end
 
-logdet_(C::Cholesky) = sum(diag(C.factors))
+logdet_(C::Cholesky) = sum(log.(diag(C.factors)))
 # Factor out computations common to the `elbo` and `dtc`.
 function _compute_intermediates(fx::FiniteGP, y::AbstractVector{<:Real}, fz::FiniteGP)
     length(fx) == length(y) || throw(

--- a/test/sparse_approximations.jl
+++ b/test/sparse_approximations.jl
@@ -133,7 +133,7 @@ end
 end
 
 @testset "logdet" begin
-    l = LowerTriangular(rand(3,3))
+    l = LowerTriangular(rand(3, 3))
     C = Cholesky(l)
     @test logdet(C) ≈ AbstractGPs.logdet_(C)
 end

--- a/test/sparse_approximations.jl
+++ b/test/sparse_approximations.jl
@@ -131,3 +131,9 @@ end
         @test AbstractGPs.tr_Cf_invΣy(fx, Σy) ≈ tr(Cf / Matrix(Σy))
     end
 end
+
+@testset "logdet" begin
+    l = LowerTriangular(rand(3,3))
+    C = Cholesky(l)
+    @test logdet(C) ≈ AbstractGPs.logdet_(C)
+end


### PR DESCRIPTION
This enables the computation of `dtc` on GPU