### PR TITLE
Do not re-evaluate the objective function

### DIFF
--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -76,7 +76,7 @@ result = optimize(
     ),
     Optim.Options(; show_every=100),
 )
-θ_final = unflatten(result.minimizer);
+θ_final = unflatten(result.minimizer)
 
 # Construct the posterior GP with the optimal model parameters:
 Σ_obs_final = observation_variance(θ_final, x)
@@ -93,6 +93,10 @@ with_theme(
         Axis=(limits=((0, 10), nothing),),
     ),
 ) do
+    # Fix numerical issues when computing the Cholesky decomposition of the covariance matrix
+    # of the finite projection of the posterior GP by introducing artifical noise
+    f_post_jitter = f_post(x, 1e-8)
+
     plot(
         x,
         f_post(x, Σ_obs_final);
@@ -100,8 +104,8 @@ with_theme(
         label="posterior + noise",
         color=(:orange, 0.3),
     )
-    plot!(x, f_post; bandscale=3, label="posterior")
-    gpsample!(x, f_post; samples=10, color=Set1_4[3])
+    plot!(x, f_post_jitter; bandscale=3, label="posterior")
+    gpsample!(x, f_post_jitter; samples=10, color=Set1_4[3])
     scatter!(x, y; label="y")
     axislegend()
     current_figure()

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -74,7 +74,7 @@ result = optimize(
         alphaguess=Optim.LineSearches.InitialStatic(; scaled=true),
         linesearch=Optim.LineSearches.BackTracking(),
     ),
-    Optim.Options(; iterations=4_000),
+    Optim.Options(; show_every=100),
 )
 θ_final = unflatten(result.minimizer);
 

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -18,7 +18,7 @@ using Zygote
 
 using LinearAlgebra
 using Random
-Random.seed!(42)  # setting the seed for reproducibility of this notebook
+Random.seed!(12)  # setting the seed for reproducibility of this notebook
 #md nothing #hide
 
 # Specify simple GP:

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -93,8 +93,8 @@ with_theme(
         Axis=(limits=((0, 10), nothing),),
     ),
 ) do
-    # Fix numerical issues when computing the Cholesky decomposition of the covariance matrix
-    # of the finite projection of the posterior GP by introducing artifical noise
+    ## Fix numerical issues when computing the Cholesky decomposition of the covariance matrix
+    ## of the finite projection of the posterior GP by introducing artifical noise
     f_post_jitter = f_post(x, 1e-8)
 
     plot(

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -18,7 +18,7 @@ using Zygote
 
 using LinearAlgebra
 using Random
-Random.seed!(12)  # setting the seed for reproducibility of this notebook
+Random.seed!(1234)  # setting the seed for reproducibility of this notebook
 #md nothing #hide
 
 # Specify simple GP:

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -22,7 +22,7 @@ Random.seed!(42)  # setting the seed for reproducibility of this notebook
 #md nothing #hide
 
 # In this example we work with a simple GP with a Gaussian kernel and heteroscedastic observation variance.
-observation_variance(θ, x::AbstractVector{<:Real}) = Diagonal(θ.σ² .* x .^ 2)
+observation_variance(θ, x::AbstractVector{<:Real}) = Diagonal(0.01 .+ θ.σ² .* x .^ 2)
 function build_gpx(θ, x::AbstractVector{<:Real})
     Σ = observation_variance(θ, x)
     return GP(0, θ.s * with_lengthscale(SEKernel(), θ.l))(x, Σ)

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -74,9 +74,8 @@ result = optimize(
         alphaguess=Optim.LineSearches.InitialStatic(; scaled=true),
         linesearch=Optim.LineSearches.BackTracking(),
     ),
-    Optim.Options(; iterations=4_000);
-    inplace=false,
-);
+    Optim.Options(; iterations=4_000),
+)
 θ_final = unflatten(result.minimizer);
 
 # Construct the posterior GP with the optimal model parameters:

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -22,10 +22,11 @@ Random.seed!(42)  # setting the seed for reproducibility of this notebook
 #md nothing #hide
 
 # In this example we work with a simple GP with a Gaussian kernel and heteroscedastic observation variance.
+observation_variance(θ, x::AbstractVector{<:Real}) = Diagonal(θ.σ² .* x .^ 2)
 function build_gpx(θ, x::AbstractVector{<:Real})
-    Σ = Diagonal(0.01 .+ θ.σ² .* x .^ 2)
+    Σ = observation_variance(θ, x)
     return GP(0, θ.s * with_lengthscale(SEKernel(), θ.l))(x, Σ)
-end
+end;
 
 # We specify the following hyperparameters:
 const flat_θ, unflatten = ParameterHandling.value_flatten((
@@ -94,7 +95,7 @@ with_theme(
 ) do
     plot(
         x,
-        f_post(x, Σ_obs_final);
+        f_post(x, observation_variance(θ_final, x));
         bandscale=3,
         label="posterior + noise",
         color=(:orange, 0.3),

--- a/examples/3-parametric-heteroscedastic/script.jl
+++ b/examples/3-parametric-heteroscedastic/script.jl
@@ -22,7 +22,7 @@ Random.seed!(42)  # setting the seed for reproducibility of this notebook
 #md nothing #hide
 
 # In this example we work with a simple GP with a Gaussian kernel and heteroscedastic observation variance.
-function build_gpx(θ, x::AbstractVector{<:Real}
+function build_gpx(θ, x::AbstractVector{<:Real})
     Σ = Diagonal(0.01 .+ θ.σ² .* x .^ 2)
     return GP(0, θ.s * with_lengthscale(SEKernel(), θ.l))(x, Σ)
 end


### PR DESCRIPTION
When working on #338, I noticed that potentially the optimization procedure in this example can be improved by not re-evaluating the objective function.

I assume if this turns out to be beneficial (I assume so but we'll see) then maybe the example in ParameterHandling could be updated as well or extended with a note in the tips and tricks section.