### PR TITLE
Fix broken link in docs

### DIFF
--- a/examples/1-mauna-loa/script.jl
+++ b/examples/1-mauna-loa/script.jl
@@ -262,7 +262,7 @@ opt_result
 #     and then picked the result with the highest marginal likelihood. We omit
 #     this for simplicity. For more details on how to fit GPs in practice,
 #     check out [A Practical Guide to Gaussian
-#     Processes](https://tinyurl.com/guide2gp).
+#     Processes](https://infallible-thompson-49de36.netlify.app/).
 #
 # Let's construct the posterior GP with the optimized hyperparameters:
 


### PR DESCRIPTION
**Summary**
The link to the practical guide seems to be broken.

**Proposed changes**
I replaced the link by another one that works. I'm not sure whether this is in fact the same article, but from the author's list it seems plausible that this is in fact the same or a newer version.
Could someone who remembers the original confirm this?
