### PR TITLE
fix deprecation of `dtc`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.18"
+version = "0.5.19"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -6,5 +6,17 @@
     plt, gp; samples=n, kwargs...
 )
 
-@deprecate elbo(dtc::DTC, fx, y) approx_log_evidence(dtc, fx, y)
-@deprecate dtc(vfe::Union{VFE,DTC}, fx, y) approx_log_evidence(vfe, fx, y)
+@deprecate dtc(dtc::DTC, fx, y) approx_log_evidence(dtc, fx, y)
+
+function _warn_elbo_called_with_DTC(dtc::DTC, fx, y)
+    @warn "`elbo` was called with an object of type `DTC`, but should only be called with the `VFE` type instead"
+    return elbo(VFE(dtc.fz), fx, y)
+end
+
+function _warn_dtc_called_with_VFE(vfe::VFE, fx, y)
+    @warn "`dtc` was called with an object of type `VFE`, but instead you should call `approx_log_evidence` with an object of type `DTC`"
+    return approx_log_evidence(DTC(vfe.fz), fx, y)
+end
+
+@deprecate elbo(dtc::DTC, fx, y) _warn_elbo_called_with_DTC(dtc, fx, y)
+@deprecate dtc(vfe::VFE, fx, y) _warn_dtc_called_with_VFE(vfe, fx, y)


### PR DESCRIPTION
The deprecations in #361 had one flaw: previously,
```julia
dtc(VFE(fz), fx, y)
```
was technically correct (though it would have been better form to use the `DTC` alias defined as `const DTC = VFE` instead).

However, the deprecations passed this on to `approx_log_evidence`, which then would just compute the VFE ELBO.

This PR catches this special case.