### PR TITLE
Resolve issues with Zygote.jl and `mean_vector`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.21"
+version = "0.5.22"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/mean_function.jl
+++ b/src/mean_function.jl
@@ -44,23 +44,12 @@ mean_vector(m::ConstMean, x::AbstractVector) = Fill(m.c, length(x))
 
 A wrapper around whatever unary function you fancy. Must be able to be mapped over an
 `AbstractVector` of inputs.
-
-# Warning
-`CustomMean` is generally sufficient for testing purposes, but care should be taken if
-attempting to differentiate through `mean_vector` with a `CustomMean` when using
-`Zygote.jl`. In particular, `mean_vector(m::CustomMean, x)` is implemented as `map(m.f, x)`,
-which when `x` is a `ColVecs` or `RowVecs` will not differentiate correctly.
-
-In such cases, you should implement `mean_vector` directly for your custom mean.
-For example, if `f(x) = sum(x)`, you might implement `mean_vector` as
-```julia
-mean_vector(::CustomMean{typeof(f)}, x::ColVecs) = vec(sum(x.X; dims=1))
-mean_vector(::CustomMean{typeof(f)}, x::RowVecs) = vec(sum(x.X; dims=2))
-```
-which avoids ever applying `map` to a `ColVecs` or `RowVecs`.
 """
 struct CustomMean{Tf} <: MeanFunction
     f::Tf
 end
 
 mean_vector(m::CustomMean, x::AbstractVector) = map(m.f, x)
+
+mean_vector(m::CustomMean, x::ColVecs) = map(m.f, eachcol(x.X))
+mean_vector(m::CustomMean, x::RowVecs) = map(m.f, eachrow(x.X))


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->

There is an issue with Zygote.jl not being able to correctly differentiate through `mean_vector`. It is described in [the docstring of `CustomMean`](https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/blob/8d431a2ed31e3bf937640948c87aa85948ab8688/src/mean_function.jl#L42C1-L66C60). It proposes to the user to implement custom methods for their particular mean function if they wish to use Zygote.jl. This seems unnecessarily clumsy.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->

Correct me if I'm wrong, but I think this issue can be resolved by simply defining special methods for `ColVecs` and `RowVecs` as proposed in this PR. This way, Zygote.jl should work with `CustomMean` out of the box.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

nothing

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->

This should not introduce any breaking changes to users who already resolved the issue by defining their own methods as described in the current docstring.
