### PR TITLE
Do Not Use Deprecated Behaviour

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractGPs"
 uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.5.22"
+version = "0.5.23"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-AbstractGPs = "0.4, 0.5"
+AbstractGPs = "0.5"
 Documenter = "1"

--- a/src/util/TestUtils.jl
+++ b/src/util/TestUtils.jl
@@ -212,7 +212,9 @@ function test_internal_abstractgps_interface(
     @test logpdf(fx, y) isa Real
     @test elbo(VFE(f(x, jitter)), fx, y) ≈ logpdf(fx, y) rtol = 1e-5 atol = 1e-5
     @test elbo(VFE(f(z, jitter)), fx, y) <= logpdf(fx, y)
-    @test dtc(VFE(f(x, jitter)), fx, y) ≈ logpdf(fx, y) rtol = 1e-5 atol = 1e-5
+    @test isapprox(
+        approx_log_evidence(VFE(f(x, jitter)), fx, y), logpdf(fx, y); rtol=1e-5, atol=1e-5
+    )
 end
 
 end

--- a/test/sparse_approximations.jl
+++ b/test/sparse_approximations.jl
@@ -108,7 +108,7 @@
             jitter = T(1e-12)
 
             @test elbo(ApproxType(f(x, jitter)), fx, y) isa T
-            @test dtc(ApproxType(f(x, jitter)), fx, y) isa T
+            @test approx_log_evidence(ApproxType(f(x, jitter)), fx, y) isa T
 
             post = posterior(ApproxType(f(x, jitter)), fx, y)
             p_fx = post(x, jitter)


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->
We deprecated `dtc` in favour of `approx_log_evidence` a while, but were still calling it in our test suite in a couple of places.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
Replace all calls to `dtc` with `approx_log_evidence`

<!-- A clear and concise description of the contents of this pull request. -->
See above

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
None

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
None
